### PR TITLE
ddms0.0.3-alpha Final Commit

### DIFF
--- a/bin/ddms
+++ b/bin/ddms
@@ -6,6 +6,8 @@
 # is implemented in ddms.php
 #
 
+clear
+
 set -o posix
 
 logErrorMsg() {

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -14,7 +14,7 @@ $banner = "\e[0m\e[94m    _    _\e[0m
 \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
 \e[0m\e[103m       v0.0.1      \e[0m";
 
-$ui->notify($banner  . PHP_EOL . "\e[0m\e[101m\e[94m    " . date('h:i:s A') . "    \e[0m", 'banner');
+$ui->showMessage($banner  . PHP_EOL . "\e[0m\e[101m\e[94m    " . date('h:i:s A') . "    \e[0m");
 
 $ddmsHelp = $commandFactory->getCommandInstance((isset($argv[1]) ? str_replace('--', '', $argv[1]) : 'help'), $ui);;
 $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -24,15 +24,18 @@ $banner = "
 $ui->showMessage($banner);
 $arguments = $ddms->prepareArguments($argv);
 foreach($arguments['options'] as $key => $option) {
-    $ui->showMessage(PHP_EOL . "\e[0m\e[105m\e[30m    Option \e[0m\e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$option\e[0m" . PHP_EOL);
+    $ui->showMessage(PHP_EOL . "\e[0m  \e[105m\e[30mOption \e[0m\e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$option\e[0m" . PHP_EOL);
 }
 foreach($arguments['flags'] as $key => $flags) {
-    $ui->showMessage(PHP_EOL . "\e[0m\e[105m\e[30m    Flag \e[0m\e[101m\e[30m$key\e[0m" . PHP_EOL);
+    $ui->showMessage(PHP_EOL . "\e[0m  \e[105m\e[30mFlag \e[0m\e[101m\e[30m$key\e[0m" . PHP_EOL);
     foreach($flags as $key => $flagArgument) {
-        $ui->showMessage(PHP_EOL . "\e[0m\e[105m\e[30m    Flag Argument \e[0m\e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$flagArgument\e[0m" . PHP_EOL);
+        $ui->showMessage(PHP_EOL . "\e[0m  \e[105m\e[30mFlag Argument \e[0m\e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$flagArgument\e[0m" . PHP_EOL);
     }
 }
 
 $ddms->runCommand($ui, $help, $argv);
-
-$ddms->run($ui, $ddms->prepareArguments($argv));
+try {
+    $ddms->run($ui, $ddms->prepareArguments($argv));
+} catch(\RuntimeException $ddmsError) {
+    $ui->showMessage(PHP_EOL . "\e[0m  \e[103m\e[30m" . str_replace(['Error', 'ddms --help'], ["\e[0m\e[102m\e[30mError\e[0m\e[103m\e[30m", "\e[0m\e[104m\e[30mddms --help\e[0m\e[103m\e[30m"], $ddmsError->getMessage()) . "\e[0m" . PHP_EOL);
+}

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -34,3 +34,5 @@ foreach($arguments['flags'] as $key => $flags) {
 }
 
 $ddms->runCommand($ui, $help, $argv);
+
+$ddms->run($ui, $ddms->prepareArguments($argv));

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -11,21 +11,15 @@ $ui = new UserInterface();
 $commandFactory = new CommandFactory();
 $help = new Help();
 $ddms = new DDMS();
-
-$banner = "
-  \e[0m\e[94m    _    _\e[0m
-  \e[0m\e[93m __| |__| |_ __  ___\e[0m
-  \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
-  \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-  \e[0m\e[105m\e[30m  v0.0.1  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m
-
-";
-
-$ui->showMessage($banner);
-
-$ddms->runCommand($ui, $help, $argv);
-
 $arguments = $ddms->prepareArguments($argv);
+
+$ui->showMessage(getBanner());
+
+try {
+    $ddms->run($ui, $ddms->prepareArguments($argv));
+} catch(\RuntimeException $ddmsError) {
+    $ui->showMessage(getDevInvalidCommandMsg($ddmsError));
+}
 
 if(in_array('DEBUGOPTIONS' ,$arguments['options'])) {
     showOptions($ui, $arguments);
@@ -34,13 +28,6 @@ if(in_array('DEBUGOPTIONS' ,$arguments['options'])) {
 if(in_array('DEBUGFLAGS' ,$arguments['options'])) {
     showFlags($ui, $arguments);
 }
-
-try {
-    $ddms->run($ui, $ddms->prepareArguments($argv));
-} catch(\RuntimeException $ddmsError) {
-    $ui->showMessage(PHP_EOL . "\e[0m  \e[103m\e[30m" . str_replace(['Error', 'ddms --help'], ["\e[0m\e[102m\e[30mError\e[0m\e[103m\e[30m", "\e[0m\e[104m\e[30mddms --help\e[0m\e[103m\e[30m"], $ddmsError->getMessage()) . "\e[0m" . PHP_EOL);
-}
-
 
 /**
  * Dev Functions
@@ -73,4 +60,33 @@ function showFlags(UserInterface $ui, array $arguments): void
         }
         $ui->showMessage(PHP_EOL);
     }
+}
+
+function getBanner():string
+{
+    return
+    $banner = "
+  \e[0m\e[94m    _    _\e[0m
+  \e[0m\e[93m __| |__| |_ __  ___\e[0m
+  \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
+  \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
+  \e[0m\e[105m\e[30m  v0.0.1  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
+
+}
+
+function getDevInvalidCommandMsg(\RuntimeException $ddmsError): string
+{
+    return PHP_EOL .
+            "\e[0m  \e[103m\e[30m" .
+            str_replace(
+                [
+                    'Error',
+                    'ddms --help'
+                ],
+                [
+                    "\e[0m\e[102m\e[30mError\e[0m\e[103m\e[30m",
+                    "\e[0m\e[104m\e[30mddms --help\e[0m\e[103m\e[30m"
+                ],
+                $ddmsError->getMessage()
+            ) . "\e[0m" . PHP_EOL;
 }

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -2,12 +2,12 @@
 
 require str_replace('bin', '', __DIR__) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
 
-use ddms\classes\ui\CommandLineUI as DDMSCommandLineUI;
+use ddms\classes\ui\CommandLineUI as UserInterface;
 use ddms\classes\command\Help;
 use ddms\classes\command\DDMS;
 use ddms\classes\factory\CommandFactory;
 
-$ui = new DDMSCommandLineUI();
+$ui = new UserInterface();
 $commandFactory = new CommandFactory();
 $help = new Help();
 $ddms = new DDMS();
@@ -22,20 +22,55 @@ $banner = "
 ";
 
 $ui->showMessage($banner);
-$arguments = $ddms->prepareArguments($argv);
-foreach($arguments['options'] as $key => $option) {
-    $ui->showMessage(PHP_EOL . "\e[0m  \e[105m\e[30mOption \e[0m\e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$option\e[0m" . PHP_EOL);
-}
-foreach($arguments['flags'] as $key => $flags) {
-    $ui->showMessage(PHP_EOL . "\e[0m  \e[105m\e[30mFlag \e[0m\e[101m\e[30m$key\e[0m" . PHP_EOL);
-    foreach($flags as $key => $flagArgument) {
-        $ui->showMessage(PHP_EOL . "\e[0m  \e[105m\e[30mFlag Argument \e[0m\e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$flagArgument\e[0m" . PHP_EOL);
-    }
-}
 
 $ddms->runCommand($ui, $help, $argv);
+
+$arguments = $ddms->prepareArguments($argv);
+
+if(in_array('DEBUGOPTIONS' ,$arguments['options'])) {
+    showOptions($ui, $arguments);
+}
+
+if(in_array('DEBUGFLAGS' ,$arguments['options'])) {
+    showFlags($ui, $arguments);
+}
+
 try {
     $ddms->run($ui, $ddms->prepareArguments($argv));
 } catch(\RuntimeException $ddmsError) {
     $ui->showMessage(PHP_EOL . "\e[0m  \e[103m\e[30m" . str_replace(['Error', 'ddms --help'], ["\e[0m\e[102m\e[30mError\e[0m\e[103m\e[30m", "\e[0m\e[104m\e[30mddms --help\e[0m\e[103m\e[30m"], $ddmsError->getMessage()) . "\e[0m" . PHP_EOL);
+}
+
+
+/**
+ * Dev Functions
+ */
+
+/**
+ * @param UserInterface $ui
+ * @param array<mixed> $arguments
+ */
+function showOptions(UserInterface $ui, array $arguments): void
+{
+    $ui->showMessage('  Options:' . PHP_EOL);
+    foreach($arguments['options'] as $key => $option) {
+        $ui->showMessage("\e[0m  \e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$option\e[0m" . PHP_EOL);
+    }
+    $ui->showMessage(PHP_EOL);
+}
+
+/**
+ * @param UserInterface $ui
+ * @param array<mixed> $arguments
+ */
+function showFlags(UserInterface $ui, array $arguments): void
+{
+    $ui->showMessage('  Flags:' . PHP_EOL);
+    foreach($arguments['flags'] as $key => $flags) {
+        $ui->showMessage("\e[0m  \e[101m\e[30m--$key\e[0m" . ": ");
+        foreach($flags as $key => $flagArgument) {
+            $ui->showMessage("\e[0m  \e[104m\e[30m$flagArgument\e[0m" . ", ");
+        }
+        $ui->showMessage(PHP_EOL);
+    }
 }

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -8,13 +8,16 @@ use ddms\classes\factory\CommandFactory;
 
 $ui = new DDMSCommandLineUI();
 $commandFactory = new CommandFactory();
-$banner = "\e[0m\e[94m    _    _\e[0m
-\e[0m\e[93m __| |__| |_ __  ___\e[0m
-\e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
-\e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-\e[0m\e[103m       v0.0.1      \e[0m";
+$banner = "
+  \e[0m\e[94m    _    _\e[0m
+  \e[0m\e[93m __| |__| |_ __  ___\e[0m
+  \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
+  \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
+  \e[0m\e[105m\e[30m  v0.0.1  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m
 
-$ui->showMessage($banner  . PHP_EOL . "\e[0m\e[101m\e[94m    " . date('h:i:s A') . "    \e[0m");
+";
+
+$ui->showMessage($banner);
 
 $ddmsHelp = $commandFactory->getCommandInstance((isset($argv[1]) ? str_replace('--', '', $argv[1]) : 'help'), $ui);;
 $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -3,11 +3,15 @@
 require str_replace('bin', '', __DIR__) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
 
 use ddms\classes\ui\CommandLineUI as DDMSCommandLineUI;
-use ddms\classes\command\Help as DDMSHelp;
+use ddms\classes\command\Help;
+use ddms\classes\command\DDMS;
 use ddms\classes\factory\CommandFactory;
 
 $ui = new DDMSCommandLineUI();
 $commandFactory = new CommandFactory();
+$help = new Help();
+$ddms = new DDMS();
+
 $banner = "
   \e[0m\e[94m    _    _\e[0m
   \e[0m\e[93m __| |__| |_ __  ___\e[0m
@@ -18,7 +22,4 @@ $banner = "
 ";
 
 $ui->showMessage($banner);
-
-$ddmsHelp = $commandFactory->getCommandInstance((isset($argv[1]) ? str_replace('--', '', $argv[1]) : 'help'), $ui);;
-$ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));
-
+$ddms->runCommand($ui, $help, $argv);

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -22,4 +22,15 @@ $banner = "
 ";
 
 $ui->showMessage($banner);
+$arguments = $ddms->prepareArguments($argv);
+foreach($arguments['options'] as $key => $option) {
+    $ui->showMessage(PHP_EOL . "\e[0m\e[105m\e[30m    Option \e[0m\e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$option\e[0m" . PHP_EOL);
+}
+foreach($arguments['flags'] as $key => $flags) {
+    $ui->showMessage(PHP_EOL . "\e[0m\e[105m\e[30m    Flag \e[0m\e[101m\e[30m$key\e[0m" . PHP_EOL);
+    foreach($flags as $key => $flagArgument) {
+        $ui->showMessage(PHP_EOL . "\e[0m\e[105m\e[30m    Flag Argument \e[0m\e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$flagArgument\e[0m" . PHP_EOL);
+    }
+}
+
 $ddms->runCommand($ui, $help, $argv);

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -3,11 +3,15 @@
 require str_replace('bin', '', __DIR__) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
 
 use ddms\classes\ui\CommandLineUI as DDMSCommandLineUI;
+use ddms\classes\command\DDMSHelp;
 
 $ui = new DDMSCommandLineUI();
 
 $ui->notify(
-    'ddms is still under development. ' . PHP_EOL . PHP_EOL .
-    'For more information please visit https://github.com/sevidmusic/ddms',
+    "ddms is still under development.\e[0m" . PHP_EOL . PHP_EOL .
+    "\e[0m\e[107m\e[30mFor more information please visit: \e[0m\e[105m\e[30mhttps://github.com/sevidmusic/ddms\e[0m",
     DDMSCommandLineUI::WARNING
 );
+
+$ddmsHelp = new DDMSHelp();
+$ddmsHelp->run($ui);

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -6,12 +6,12 @@ use ddms\classes\ui\CommandLineUI as DDMSCommandLineUI;
 use ddms\classes\command\DDMSHelp;
 
 $ui = new DDMSCommandLineUI();
+$banner = "\e[0m\e[94m    _    _\e[0m
+\e[0m\e[93m __| |__| |_ __  ___\e[0m
+\e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
+\e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
+\e[0m\e[103m                    \e[0m";
 
-$ui->notify(
-    "ddms is still under development.\e[0m" . PHP_EOL . PHP_EOL .
-    "\e[0m\e[107m\e[30mFor more information please visit: \e[0m\e[105m\e[30mhttps://github.com/sevidmusic/ddms\e[0m",
-    DDMSCommandLineUI::WARNING
-);
-
+$ui->notify($banner, ':)');
 $ddmsHelp = new DDMSHelp();
-$ddmsHelp->run($ui);
+$ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -12,6 +12,6 @@ $banner = "\e[0m\e[94m    _    _\e[0m
 \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
 \e[0m\e[103m                    \e[0m";
 
-$ui->notify($banner, ':)');
+$ui->notify($banner, 'banner');
 $ddmsHelp = new DDMSHelp();
 $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -4,8 +4,10 @@ require str_replace('bin', '', __DIR__) . DIRECTORY_SEPARATOR . 'vendor/autoload
 
 use ddms\classes\ui\CommandLineUI as DDMSCommandLineUI;
 use ddms\classes\command\Help as DDMSHelp;
+use ddms\classes\factory\CommandFactory;
 
 $ui = new DDMSCommandLineUI();
+$commandFactory = new CommandFactory();
 $banner = "\e[0m\e[94m    _    _\e[0m
 \e[0m\e[93m __| |__| |_ __  ___\e[0m
 \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
@@ -13,7 +15,9 @@ $banner = "\e[0m\e[94m    _    _\e[0m
 \e[0m\e[103m       v0.0.1      \e[0m";
 
 $ui->notify($banner  . PHP_EOL . "\e[0m\e[101m\e[94m    " . date('h:i:s A') . "    \e[0m", 'banner');
-$ddmsHelp = new DDMSHelp();
+
+$ddmsHelp = $commandFactory->getCommandInstance('invalidCommand', $ui);;
+#$ddmsHelp = $commandFactory->getCommandInstance('help', $ui);;
 $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));
 
 

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -16,6 +16,6 @@ $banner = "\e[0m\e[94m    _    _\e[0m
 
 $ui->notify($banner  . PHP_EOL . "\e[0m\e[101m\e[94m    " . date('h:i:s A') . "    \e[0m", 'banner');
 
-$ddmsHelp = $commandFactory->getCommandInstance((isset($argv[1]) ? $argv[1] : 'help'), $ui);;
+$ddmsHelp = $commandFactory->getCommandInstance((isset($argv[1]) ? str_replace('--', '', $argv[1]) : 'help'), $ui);;
 $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));
 

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -39,9 +39,9 @@ if(in_array('DEBUGFLAGS' ,$arguments['options'])) {
  */
 function showOptions(UserInterface $ui, array $arguments): void
 {
-    $ui->showMessage('  Options:' . PHP_EOL);
+    $ui->showMessage(PHP_EOL . '  Options:' . PHP_EOL);
     foreach($arguments['options'] as $key => $option) {
-        $ui->showMessage("\e[0m  \e[101m\e[30m$key\e[0m\e[105m\e[30m: \e[0m\e[104m\e[30m$option\e[0m" . PHP_EOL);
+        $ui->showMessage("\e[0m  \e[101m\e[30m $key \e[0m\e[105m\e[30m : \e[0m\e[104m\e[30m $option \e[0m" . PHP_EOL);
     }
     $ui->showMessage(PHP_EOL);
 }
@@ -54,9 +54,9 @@ function showFlags(UserInterface $ui, array $arguments): void
 {
     $ui->showMessage('  Flags:' . PHP_EOL);
     foreach($arguments['flags'] as $key => $flags) {
-        $ui->showMessage("\e[0m  \e[101m\e[30m--$key\e[0m" . ": ");
+        $ui->showMessage("\e[0m  \e[101m\e[30m --$key \e[0m" . " : ");
         foreach($flags as $key => $flagArgument) {
-            $ui->showMessage("\e[0m  \e[104m\e[30m$flagArgument\e[0m" . ", ");
+            $ui->showMessage("\e[0m\e[104m\e[30m $flagArgument \e[0m" . "  ");
         }
         $ui->showMessage(PHP_EOL);
     }

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -3,15 +3,21 @@
 require str_replace('bin', '', __DIR__) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
 
 use ddms\classes\ui\CommandLineUI as DDMSCommandLineUI;
-use ddms\classes\command\DDMSHelp;
+use ddms\classes\command\Help as DDMSHelp;
 
 $ui = new DDMSCommandLineUI();
 $banner = "\e[0m\e[94m    _    _\e[0m
 \e[0m\e[93m __| |__| |_ __  ___\e[0m
 \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
 \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-\e[0m\e[103m                    \e[0m";
+\e[0m\e[103m       v0.0.1      \e[0m";
 
-$ui->notify($banner, 'banner');
+$ui->notify($banner  . PHP_EOL . "\e[0m\e[101m\e[94m    " . date('h:i:s A') . "    \e[0m", 'banner');
 $ddmsHelp = new DDMSHelp();
 $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));
+
+
+# $ddmsCommandFactory = new DDMSCommandFactory();
+# $ddmsHelp = $ddmsCommandFactory->buidHelpInstance();
+# $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));
+

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -16,12 +16,6 @@ $banner = "\e[0m\e[94m    _    _\e[0m
 
 $ui->notify($banner  . PHP_EOL . "\e[0m\e[101m\e[94m    " . date('h:i:s A') . "    \e[0m", 'banner');
 
-$ddmsHelp = $commandFactory->getCommandInstance('invalidCommand', $ui);;
-#$ddmsHelp = $commandFactory->getCommandInstance('help', $ui);;
+$ddmsHelp = $commandFactory->getCommandInstance((isset($argv[1]) ? $argv[1] : 'help'), $ui);;
 $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));
-
-
-# $ddmsCommandFactory = new DDMSCommandFactory();
-# $ddmsHelp = $ddmsCommandFactory->buidHelpInstance();
-# $ddmsHelp->run($ui, $ddmsHelp->prepareArguments($argv));
 

--- a/ddms/abstractions/command/AbstractCommand.php
+++ b/ddms/abstractions/command/AbstractCommand.php
@@ -2,13 +2,13 @@
 
 namespace ddms\abstractions\command;
 
-use ddms\interfaces\command\Command as DDMSCommand;
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+use ddms\interfaces\command\Command;
+use ddms\interfaces\ui\UserInterface;
 use \RecursiveIteratorIterator;
 use \RecursiveArrayIterator;
 
 
-abstract class AbstractCommand implements DDMSCommand
+abstract class AbstractCommand implements Command
 {
 
     public function prepareArguments(array $argv): array
@@ -58,7 +58,7 @@ abstract class AbstractCommand implements DDMSCommand
         return false;
     }
 
-    abstract public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool;
+    abstract public function run(UserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool;
 
     /**
      * Flatten a multi-dimensional array. Keys are not preserved, unless

--- a/ddms/abstractions/command/AbstractCommand.php
+++ b/ddms/abstractions/command/AbstractCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace ddms\abstractions\command;
+
+use ddms\interfaces\command\Command as DDMSCommand;
+use \RecursiveIteratorIterator;
+use \RecursiveArrayIterator;
+
+abstract class AbstractCommand implements DDMSCommand
+{
+
+    public function prepareArguments(array $argv): array
+    {
+        return $this->distiguishFlagsAndOptions($this->flattenArray($this->convertValuesToStrings($argv)));
+    }
+
+    /**
+     * @param array<int, string> $argv
+     * @return array{"flags": array<string, array<int, string>>, "options": array<int, string>}
+     */
+    private function distiguishFlagsAndOptions(array $argv): array
+    {
+        $args = ['flags' => [], 'options' => []];
+        foreach($argv as $position => $arg) {
+            if(substr($arg, 0, 2) === '--') {
+                $args['flags'][str_replace('--' , '', $arg)] = [];
+                $nextItemKey = $position + 1;
+                while(isset($argv[$nextItemKey]) && substr($argv[$nextItemKey], 0, 2) !== '--') {
+                    $args['flags'][str_replace('--' , '', $arg)][] = $argv[$nextItemKey];
+                    $nextItemKey++;
+                }
+                continue;
+            }
+            if (!$this->in_array_recursive($arg, $args['flags'])) {
+                $args['options'][$position] = $arg;
+            }
+        }
+        return $args;
+    }
+
+    /**
+     * @param mixed $haystack
+     * @param array<mixed> $haystack
+     * @return bool
+     */
+    private function in_array_recursive(string $needle, array $haystack): bool
+    {
+        foreach($haystack as $value) {
+            if($value === $needle) {
+                return true;
+            }
+            if (is_array($value) && $this->in_array_recursive($needle, $value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    abstract public function run(array $preparedArguments): bool;
+
+    /**
+     * Flatten a multi-dimensional array. Keys are not preserved, unless
+     * key of type string, in which case it will become a value in the
+     * new array.
+     * @param array<mixed> $array
+     *
+     * @return array<int, mixed>
+     */
+    private function flattenArray(array $array): array {
+        $iterator = new RecursiveIteratorIterator(new RecursiveArrayIterator($array));
+        $flatArr = [];
+        foreach($iterator as $key => $value) {
+            if(is_string($key)) {
+                array_push($flatArr, $key);
+            }
+            array_push($flatArr, $value);
+        }
+        return $flatArr;
+    }
+
+    /**
+     * @param array<mixed> $array
+     *
+     * @return array<array|string>
+     */
+    private function convertValuesToStrings(array $array): array {
+        $convertedValues = [];
+        foreach($array as $key => $value) {
+            if(is_array($value) && !empty($value)) {
+                $convertedValues[$key] = $this->convertValuesToStrings($value);
+                continue;
+            }
+            if(is_null($value)) {
+                $value = 'null';
+            }
+            if($value === true) {
+                $value = 'true';
+            }
+            if($value === false) {
+                $value = 'false';
+            }
+            if(is_object($value)) {
+                $value = json_encode($value);
+            }
+            $convertedValues[$key] = ($value === []) ? '[]' : strval($value);
+        }
+        return $convertedValues;
+    }
+
+}

--- a/ddms/abstractions/command/AbstractCommand.php
+++ b/ddms/abstractions/command/AbstractCommand.php
@@ -3,8 +3,10 @@
 namespace ddms\abstractions\command;
 
 use ddms\interfaces\command\Command as DDMSCommand;
+use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
 use \RecursiveIteratorIterator;
 use \RecursiveArrayIterator;
+
 
 abstract class AbstractCommand implements DDMSCommand
 {
@@ -56,7 +58,7 @@ abstract class AbstractCommand implements DDMSCommand
         return false;
     }
 
-    abstract public function run(array $preparedArguments): bool;
+    abstract public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool;
 
     /**
      * Flatten a multi-dimensional array. Keys are not preserved, unless

--- a/ddms/abstractions/command/AbstractDDMS.php
+++ b/ddms/abstractions/command/AbstractDDMS.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ddms\abstractions\command;
+
+use ddms\interfaces\command\Command as DDMSCommandInterface;
+use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+use ddms\abstractions\command\AbstractCommand as DDMSCommandBase;
+
+abstract class AbstractDDMS extends DDMSCommandBase implements DDMSCommandInterface
+{
+
+    /**
+     * @param array<mixed> $argv
+     */
+    final public function runCommand(DDMSUserInterface $ddmsUI, DDMSCommandInterface $ddmsCommand, $argv): bool
+    {
+        return $ddmsCommand->run($ddmsUI, $ddmsCommand->prepareArguments($argv));
+    }
+
+}

--- a/ddms/abstractions/command/AbstractDDMS.php
+++ b/ddms/abstractions/command/AbstractDDMS.php
@@ -2,17 +2,17 @@
 
 namespace ddms\abstractions\command;
 
-use ddms\interfaces\command\Command as DDMSCommandInterface;
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
-use ddms\abstractions\command\AbstractCommand as DDMSCommandBase;
+use ddms\interfaces\command\Command;
+use ddms\interfaces\ui\UserInterface;
+use ddms\abstractions\command\AbstractCommand;
 
-abstract class AbstractDDMS extends DDMSCommandBase implements DDMSCommandInterface
+abstract class AbstractDDMS extends AbstractCommand implements Command
 {
 
     /**
      * @param array<mixed> $argv
      */
-    final public function runCommand(DDMSUserInterface $ddmsUI, DDMSCommandInterface $ddmsCommand, $argv): bool
+    final public function runCommand(UserInterface $ddmsUI, Command $ddmsCommand, $argv): bool
     {
         return $ddmsCommand->run($ddmsUI, $ddmsCommand->prepareArguments($argv));
     }

--- a/ddms/abstractions/ui/AbstractUserInterface.php
+++ b/ddms/abstractions/ui/AbstractUserInterface.php
@@ -7,8 +7,8 @@ use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
 abstract class AbstractUserInterface implements DDMSUserInterface
 {
 
-    public function notify(string $message, string $noticeType = self::NOTICE): void
+    public function showMessage(string $message): void
     {
-        echo $noticeType . ': ' . $message;
+        echo $message;
     }
 }

--- a/ddms/abstractions/ui/AbstractUserInterface.php
+++ b/ddms/abstractions/ui/AbstractUserInterface.php
@@ -2,9 +2,9 @@
 
 namespace ddms\abstractions\ui;
 
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+use ddms\interfaces\ui\UserInterface;
 
-abstract class AbstractUserInterface implements DDMSUserInterface
+abstract class AbstractUserInterface implements UserInterface
 {
 
     public function showMessage(string $message): void

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ddms\classes\command;
+
+use ddms\interfaces\command\Command;
+use ddms\abstractions\command\AbstractDDMS;
+use ddms\interfaces\ui\UserInterface;
+
+class DDMS extends AbstractDDMS implements Command
+{
+
+    public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
+    {
+        return false;
+    }
+
+}

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -18,7 +18,8 @@ class DDMS extends AbstractDDMS implements Command
             $command = $this->convertFlagToCommandName(array_shift($flags));
             $expectedCommandNamespace = "\\ddms\\classes\\command\\$command";
             if($this->commandExists($expectedCommandNamespace)) {
-                return true;
+                $commandInstance = new $expectedCommandNamespace();
+                return $commandInstance->run($userInterface, $preparedArguments);
             }
             return throw new RuntimeException("Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information.");
         }

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -12,8 +12,9 @@ class DDMS extends AbstractDDMS implements Command
 
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
-        if(!empty($preparedArguments['flags'])) {
-            $flags = array_keys($preparedArguments['flags']);
+        ['flags' => $flags] = $preparedArguments;
+        if(!empty($flags)) {
+            $flags = array_keys($flags);
             $command = $this->convertFlagToCommandName(array_shift($flags));
             $expectedCommandNamespace = "\\ddms\\classes\\command\\$command";
             if($this->commandExists($expectedCommandNamespace)) {

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -20,7 +20,7 @@ class DDMS extends AbstractDDMS implements Command
                 return true;
             }
         }
-        return throw new RuntimeException("ddms runtime Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information.");
+        return throw new RuntimeException("Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information.");
     }
 
     private function commandExists(string $expectedCommandNamespace): bool

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -20,8 +20,9 @@ class DDMS extends AbstractDDMS implements Command
             if($this->commandExists($expectedCommandNamespace)) {
                 return true;
             }
+            return throw new RuntimeException("Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information.");
         }
-        return throw new RuntimeException("Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information.");
+        return false;
     }
 
     private function commandExists(string $expectedCommandNamespace): bool

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -5,13 +5,38 @@ namespace ddms\classes\command;
 use ddms\interfaces\command\Command;
 use ddms\abstractions\command\AbstractDDMS;
 use ddms\interfaces\ui\UserInterface;
+use \RuntimeException;
 
 class DDMS extends AbstractDDMS implements Command
 {
 
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
+        if(!empty($preparedArguments['flags'])) {
+            $flags = array_keys($preparedArguments['flags']);
+            $command = $this->convertFlagToCommandName(array_shift($flags));
+            $expectedCommandNamespace = "\\ddms\\classes\\command\\$command";
+            if($this->commandExists($expectedCommandNamespace)) {
+                return true;
+            }
+        }
+        return throw new RuntimeException("ddms runtime Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information.");
+    }
+
+    private function commandExists(string $expectedCommandNamespace): bool
+    {
+        if(class_exists($expectedCommandNamespace)) {
+            $classImplements = (is_array(class_implements($expectedCommandNamespace)) ? class_implements($expectedCommandNamespace) : []);
+            if(in_array(Command::class, $classImplements)) {
+                return true;
+            }
+        }
         return false;
+    }
+
+    private function convertFlagToCommandName(string $string): string
+    {
+        return str_replace(' ', '', ucwords(str_replace('-', ' ', $string)));
     }
 
 }

--- a/ddms/classes/command/DDMSHelp.php
+++ b/ddms/classes/command/DDMSHelp.php
@@ -11,6 +11,22 @@ class DDMSHelp extends DDMSCommandBase implements DDMSCommandInterface
 
     public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
+        $ddmsUI->notify($this->getHelpFileOutput('help'), 'help');
         return true;
     }
+
+    private function getHelpFileOutput(string $helpFlagName): string
+    {
+        if(file_exists($this->determineHelpFilePath($helpFlagName)))
+        {
+            $output = file_get_contents($this->determineHelpFilePath($helpFlagName));
+        }
+        return (isset($output) && is_string($output) ? PHP_EOL . "\e[0m\e[45m\e[30m" . $output . "\e[0m" . PHP_EOL : '');
+    }
+
+    private function determineHelpFilePath(string $helpFlagName): string
+    {
+        return str_replace('ddms/classes/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
+    }
+
 }

--- a/ddms/classes/command/DDMSHelp.php
+++ b/ddms/classes/command/DDMSHelp.php
@@ -11,6 +11,10 @@ class DDMSHelp extends DDMSCommandBase implements DDMSCommandInterface
 
     public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
+        $flags = $preparedArguments['flags'];
+        if(!empty($flags) && !key_exists('help', $flags)) {
+            return false;
+        }
         $ddmsUI->notify($this->getHelpFileOutput('help'), 'help');
         return true;
     }

--- a/ddms/classes/command/DDMSHelp.php
+++ b/ddms/classes/command/DDMSHelp.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ddms\classes\command;
+
+use ddms\interfaces\command\Command as DDMSCommandInterface;
+use ddms\abstractions\command\AbstractCommand as DDMSCommandBase;
+use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+
+class DDMSHelp extends DDMSCommandBase implements DDMSCommandInterface
+{
+
+    public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool
+    {
+        return true;
+    }
+}

--- a/ddms/classes/command/Help.php
+++ b/ddms/classes/command/Help.php
@@ -2,14 +2,14 @@
 
 namespace ddms\classes\command;
 
-use ddms\interfaces\command\Command as DDMSCommandInterface;
-use ddms\abstractions\command\AbstractCommand as DDMSCommandBase;
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+use ddms\interfaces\command\Command;
+use ddms\abstractions\command\AbstractCommand;
+use ddms\interfaces\ui\UserInterface;
 
-class Help extends DDMSCommandBase implements DDMSCommandInterface
+class Help extends AbstractCommand implements Command
 {
 
-    public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool
+    public function run(UserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
         $flags = $preparedArguments['flags'];
         if(!empty($flags) && !key_exists('help', $flags)) {

--- a/ddms/classes/command/Help.php
+++ b/ddms/classes/command/Help.php
@@ -15,7 +15,7 @@ class Help extends DDMSCommandBase implements DDMSCommandInterface
         if(!empty($flags) && !key_exists('help', $flags)) {
             return false;
         }
-        $ddmsUI->notify($this->getHelpFileOutput('help'), 'help');
+        $ddmsUI->showMessage($this->getHelpFileOutput('help'));
         return true;
     }
 

--- a/ddms/classes/command/Help.php
+++ b/ddms/classes/command/Help.php
@@ -25,7 +25,7 @@ class Help extends AbstractCommand implements Command
         {
             $output = file_get_contents($this->determineHelpFilePath($helpFlagName));
         }
-        return (isset($output) && is_string($output) ? PHP_EOL . "\e[0m\e[45m\e[30m" . $output . "\e[0m" . PHP_EOL : '');
+        return (isset($output) && is_string($output) ? PHP_EOL . $output . PHP_EOL : '');
     }
 
     private function determineHelpFilePath(string $helpFlagName): string

--- a/ddms/classes/command/Help.php
+++ b/ddms/classes/command/Help.php
@@ -6,7 +6,7 @@ use ddms\interfaces\command\Command as DDMSCommandInterface;
 use ddms\abstractions\command\AbstractCommand as DDMSCommandBase;
 use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
 
-class DDMSHelp extends DDMSCommandBase implements DDMSCommandInterface
+class Help extends DDMSCommandBase implements DDMSCommandInterface
 {
 
     public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool

--- a/ddms/classes/factory/CommandFactory.php
+++ b/ddms/classes/factory/CommandFactory.php
@@ -2,19 +2,19 @@
 
 namespace ddms\classes\factory;
 
-use ddms\interfaces\factory\CommandFactory as DDMSCommandInterfaceFactory;
-use ddms\interfaces\ui\UserInterface as DDMSUIInterface;
-use ddms\interfaces\command\Command as DDMSCommandInterface;
+use ddms\interfaces\factory\CommandFactory as CommandFactoryInterface;
+use ddms\interfaces\ui\UserInterface;
+use ddms\interfaces\command\Command;
 use ddms\classes\command\Help;
 
-class CommandFactory implements DDMSCommandInterfaceFactory
+class CommandFactory implements CommandFactoryInterface
 {
 
-    public function getCommandInstance(string $commandName, DDMSUIInterface $ddmsUserInterface): DDMSCommandInterface
+    public function getCommandInstance(string $commandName, UserInterface $ddmsUserInterface): Command
     {
         $commandClassName = 'ddms\\classes\\command\\' . ucwords($commandName);
         $implements = (class_exists($commandClassName) ? class_implements($commandClassName) : []);
-        if(in_array(DDMSCommandInterface::class, (is_array($implements) ? $implements : []))) {
+        if(in_array(Command::class, (is_array($implements) ? $implements : []))) {
             return new $commandClassName();
         }
         $ddmsUserInterface->showMessage(CommandFactory::class . " Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" . $commandName . "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`.");

--- a/ddms/classes/factory/CommandFactory.php
+++ b/ddms/classes/factory/CommandFactory.php
@@ -17,7 +17,7 @@ class CommandFactory implements DDMSCommandInterfaceFactory
         if(in_array(DDMSCommandInterface::class, (is_array($implements) ? $implements : []))) {
             return new $commandClassName();
         }
-        $ddmsUserInterface->notify(CommandFactory::class . " Error: The specified command" . $commandName . ", is not valid. Defaulting to --help.", $ddmsUserInterface::ERROR);
+        $ddmsUserInterface->notify(CommandFactory::class . " Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" . $commandName . "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`.", $ddmsUserInterface::ERROR);
         return new Help();
     }
 

--- a/ddms/classes/factory/CommandFactory.php
+++ b/ddms/classes/factory/CommandFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ddms\classes\factory;
+
+use ddms\interfaces\factory\CommandFactory as DDMSCommandFactory;
+use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+use ddms\interfaces\command\Command as DDMSCommand;
+
+abstract class CommandFactory implements DDMSCommandFactory
+{
+
+    abstract public function getCommandInstance(string $commandName, DDMSUserInterface $ddmsUserInterface): DDMSCommand;
+
+}

--- a/ddms/classes/factory/CommandFactory.php
+++ b/ddms/classes/factory/CommandFactory.php
@@ -17,7 +17,7 @@ class CommandFactory implements DDMSCommandInterfaceFactory
         if(in_array(DDMSCommandInterface::class, (is_array($implements) ? $implements : []))) {
             return new $commandClassName();
         }
-        $ddmsUserInterface->notify(CommandFactory::class . " Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" . $commandName . "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`.", $ddmsUserInterface::ERROR);
+        $ddmsUserInterface->showMessage(CommandFactory::class . " Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" . $commandName . "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`.");
         return new Help();
     }
 

--- a/ddms/classes/factory/CommandFactory.php
+++ b/ddms/classes/factory/CommandFactory.php
@@ -2,13 +2,23 @@
 
 namespace ddms\classes\factory;
 
-use ddms\interfaces\factory\CommandFactory as DDMSCommandFactory;
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
-use ddms\interfaces\command\Command as DDMSCommand;
+use ddms\interfaces\factory\CommandFactory as DDMSCommandInterfaceFactory;
+use ddms\interfaces\ui\UserInterface as DDMSUIInterface;
+use ddms\interfaces\command\Command as DDMSCommandInterface;
+use ddms\classes\command\Help;
 
-abstract class CommandFactory implements DDMSCommandFactory
+class CommandFactory implements DDMSCommandInterfaceFactory
 {
 
-    abstract public function getCommandInstance(string $commandName, DDMSUserInterface $ddmsUserInterface): DDMSCommand;
+    public function getCommandInstance(string $commandName, DDMSUIInterface $ddmsUserInterface): DDMSCommandInterface
+    {
+        $commandClassName = 'ddms\\classes\\command\\' . ucwords($commandName);
+        $implements = (class_exists($commandClassName) ? class_implements($commandClassName) : []);
+        if(in_array(DDMSCommandInterface::class, (is_array($implements) ? $implements : []))) {
+            return new $commandClassName();
+        }
+        $ddmsUserInterface->notify(CommandFactory::class . " Error: The specified command" . $commandName . ", is not valid. Defaulting to --help.", $ddmsUserInterface::ERROR);
+        return new Help();
+    }
 
 }

--- a/ddms/classes/factory/CommandFactory.php
+++ b/ddms/classes/factory/CommandFactory.php
@@ -17,12 +17,6 @@ class CommandFactory implements CommandFactoryInterface
         if(in_array(Command::class, (is_array($implements) ? $implements : []))) {
             return new $commandClassName();
         }
-        $ddmsUserInterface->showMessage(
-            CommandFactory::class .
-            "Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" .
-            $commandName .
-            "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`."
-        );
         return new Help();
     }
 

--- a/ddms/classes/factory/CommandFactory.php
+++ b/ddms/classes/factory/CommandFactory.php
@@ -17,7 +17,12 @@ class CommandFactory implements CommandFactoryInterface
         if(in_array(Command::class, (is_array($implements) ? $implements : []))) {
             return new $commandClassName();
         }
-        $ddmsUserInterface->showMessage(CommandFactory::class . " Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" . $commandName . "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`.");
+        $ddmsUserInterface->showMessage(
+            CommandFactory::class .
+            "Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" .
+            $commandName .
+            "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`."
+        );
         return new Help();
     }
 

--- a/ddms/classes/ui/CommandLineUI.php
+++ b/ddms/classes/ui/CommandLineUI.php
@@ -6,14 +6,27 @@ use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
 
 class CommandLineUI implements DDMSUserInterface
 {
+
+    public const BANNER = 'banner';
+
     public function notify(string $message, string $noticeType = self::NOTICE): void
     {
-        $output = sprintf(
+        if($noticeType === self::BANNER){
+             echo sprintf(
+                "%s%s%s%s",
+                PHP_EOL,
+                $message,
+                PHP_EOL,
+                PHP_EOL,
+            );
+            return;
+        }
+        echo sprintf(
             "%s%s%s%s%s%s%s%s%s%s%s",
             PHP_EOL,
             "\e[0m\e[105m\e[30m    ",
             "\e[0m\e[92m " . date('Y-m-d @ H:i:s') . "  \e[0m ",
-            "\e[0m\e[102m\e[30m" . (empty($noticeType) ? DDMSUserInterface::NOTICE : $noticeType) . "\e[0m\e[105m\e[30m    \e[0m",
+            "\e[0m\e[102m\e[30m" . (empty($noticeType) ? self::NOTICE : $noticeType) . "\e[0m\e[105m\e[30m    \e[0m",
             PHP_EOL,
             PHP_EOL,
             "\e[0m\e[107m\e[30m",
@@ -22,7 +35,6 @@ class CommandLineUI implements DDMSUserInterface
             PHP_EOL,
             PHP_EOL,
         );
-        echo $output;
     }
 
 }

--- a/ddms/classes/ui/CommandLineUI.php
+++ b/ddms/classes/ui/CommandLineUI.php
@@ -2,12 +2,10 @@
 
 namespace ddms\classes\ui;
 
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+use ddms\interfaces\ui\UserInterface;
 
-class CommandLineUI implements DDMSUserInterface
+class CommandLineUI implements UserInterface
 {
-
-    public const BANNER = 'banner';
 
     public function showMessage(string $message): void
     {

--- a/ddms/classes/ui/CommandLineUI.php
+++ b/ddms/classes/ui/CommandLineUI.php
@@ -9,32 +9,9 @@ class CommandLineUI implements DDMSUserInterface
 
     public const BANNER = 'banner';
 
-    public function notify(string $message, string $noticeType = self::NOTICE): void
+    public function showMessage(string $message): void
     {
-        if($noticeType === self::BANNER){
-             echo sprintf(
-                "%s%s%s%s",
-                PHP_EOL,
-                $message,
-                PHP_EOL,
-                PHP_EOL,
-            );
-            return;
-        }
-        echo sprintf(
-            "%s%s%s%s%s%s%s%s%s%s%s",
-            PHP_EOL,
-            "\e[0m\e[105m\e[30m    ",
-            "\e[0m\e[92m " . date('Y-m-d @ H:i:s') . "  \e[0m ",
-            "\e[0m\e[102m\e[30m" . (empty($noticeType) ? self::NOTICE : $noticeType) . "\e[0m\e[105m\e[30m    \e[0m",
-            PHP_EOL,
-            PHP_EOL,
-            "\e[0m\e[107m\e[30m",
-            $message,
-            "\e[0m",
-            PHP_EOL,
-            PHP_EOL,
-        );
+        echo $message;
     }
 
 }

--- a/ddms/interfaces/command/Command.php
+++ b/ddms/interfaces/command/Command.php
@@ -2,15 +2,15 @@
 
 namespace ddms\interfaces\command;
 
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+use ddms\interfaces\ui\UserInterface;
 
 interface Command {
 
     /**
-     * @param DDMSUserInterface $ddmsUI
+     * @param UserInterface $userInterface
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */
-    public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool;
+    public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool;
 
     /**
      * @param array<mixed> $argv

--- a/ddms/interfaces/command/Command.php
+++ b/ddms/interfaces/command/Command.php
@@ -2,12 +2,15 @@
 
 namespace ddms\interfaces\command;
 
+use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
+
 interface Command {
 
     /**
+     * @param DDMSUserInterface $ddmsUI
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */
-    public function run(array $preparedArguments): bool;
+    public function run(DDMSUserInterface $ddmsUI, array $preparedArguments = ['flags' => [], 'options' => []]): bool;
 
     /**
      * @param array<mixed> $argv

--- a/ddms/interfaces/command/Command.php
+++ b/ddms/interfaces/command/Command.php
@@ -5,30 +5,15 @@ namespace ddms\interfaces\command;
 interface Command {
 
     /**
-     * @param array<int, string> $argv An array of values to be interpreted as arguments.
-     *                                 This will typically be the $argv array populated by
-     *                                 PHP.
-     *                                 This array should be a single-dimensional array of strings
-     *                                 with numeric indexes.
-     *                                 https://www.php.net/manual/en/reserved.variables.argv.php
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */
-    public function run(array $argv): bool;
+    public function run(array $preparedArguments): bool;
 
     /**
-     * @param array<int, string> $argv An array of values to be interpreted as arguments.
-     *                                 This will typically be the $argv array populated by
-     *                                 PHP.
-     *                                 https://www.php.net/manual/en/reserved.variables.argv.php
-     *                                 This method is intended to provide implementations a way
-     *                                 to prepare the $argv array appropriately for their use case.
-     *                                 If no preparation is required, this method MUST return the
-     *                                 $argv array unmodified.
+     * @param array<mixed> $argv
+     * @see https://www.php.net/manual/en/reserved.variables.argv.php
      *
-     * @return array<int|string,string> Either an array modified appropriately for the implementation,
-     *                                  or, if no preparation is required by the implementation, the
-     *                                  $argv array.
-     *                                  This can be a numerically or associatively indexed single or
-     *                                  multi-dimensional array so long as all values are strings.
+     * @return array{"flags": array<string, array<int, string>>, "options": array<int, string>}
      */
     public function prepareArguments(array $argv): array;
 

--- a/ddms/interfaces/factory/CommandFactory.php
+++ b/ddms/interfaces/factory/CommandFactory.php
@@ -3,12 +3,12 @@
 
 namespace ddms\interfaces\factory;
 
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
-use ddms\interfaces\command\Command as DDMSCommand;
+use ddms\interfaces\ui\UserInterface;
+use ddms\interfaces\command\Command;
 
 interface CommandFactory
 {
 
-    public function getCommandInstance(string $commandName, DDMSUserInterface $ddmsUserInterface): DDMSCommand;
+    public function getCommandInstance(string $commandName, UserInterface $ddmsUserInterface): Command;
 
 }

--- a/ddms/interfaces/ui/UserInterface.php
+++ b/ddms/interfaces/ui/UserInterface.php
@@ -4,11 +4,6 @@ namespace ddms\interfaces\ui;
 
 interface UserInterface {
 
-    public const NOTICE = 'notice';
-    public const ERROR = 'error';
-    public const WARNING = 'warning';
-    public const SUCCESS = 'success';
-
-    public function notify(string $message, string $noticeType = self::NOTICE): void;
+    public function showMessage(string $message): void;
 
 }

--- a/helpFiles/help.txt
+++ b/helpFiles/help.txt
@@ -1,17 +1,13 @@
 ddms is a command line utility designed to aide in the development process
-with the Darling Data Management System.
-
-ddms is still being developed.
+with the Darling Data Management System. ddms is still under development and
+is not ready for use.
 
 For more information go to:
-
 https://github.com/sevidmusic/ddms
 
 For more information about the Darling Data Management System go to:
-
 https://github.com/sevidmusic/DarlingDataManagementSystem
 
 Finally, for additional information about both ddms, and the Darling Data Management
 System go to:
-
 http://darlingdata.tech

--- a/helpFiles/help.txt
+++ b/helpFiles/help.txt
@@ -1,0 +1,17 @@
+ddms is a command line utility designed to aide in the development process
+with the Darling Data Management System.
+
+ddms is still being developed.
+
+For more information go to:
+
+https://github.com/sevidmusic/ddms
+
+For more information about the Darling Data Management System go to:
+
+https://github.com/sevidmusic/DarlingDataManagementSystem
+
+Finally, for additional information about both ddms, and the Darling Data Management
+System go to:
+
+http://darlingdata.tech

--- a/helpFiles/help.txt
+++ b/helpFiles/help.txt
@@ -1,13 +1,13 @@
-ddms is a command line utility designed to aide in the development process
-with the Darling Data Management System. ddms is still under development and
-is not ready for use.
+  ddms is a command line utility designed to aide in the development process
+  with the Darling Data Management System. ddms is still under development and
+  is not ready for use.
 
-For more information go to:
-https://github.com/sevidmusic/ddms
+  For more information go to:
+  https://github.com/sevidmusic/ddms
 
-For more information about the Darling Data Management System go to:
-https://github.com/sevidmusic/DarlingDataManagementSystem
+  For more information about the Darling Data Management System go to:
+  https://github.com/sevidmusic/DarlingDataManagementSystem
 
-Finally, for additional information about both ddms, and the Darling Data Management
-System go to:
-http://darlingdata.tech
+  Finally, for additional information about both ddms, and the Darling Data Management
+  System go to:
+  http://darlingdata.tech

--- a/tests/command/AbstractCommandTest.php
+++ b/tests/command/AbstractCommandTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace tests\command\AbstractCommand;
+
+use PHPUnit\Framework\TestCase;
+use ddms\abstractions\command\AbstractCommand as DDMSCommand;
+
+final class AbstractCommandTest extends TestCase
+{
+
+    public function testPrepareArgumentsReturnsAnArrayWhoseNonRecursiveCountIsTwo(): void
+    {
+        $this->assertEquals(2, count($this->getMockCommand()->prepareArguments($this->getMockArray())));
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayWhoseTopLevelIndexesAre_flags__And__options(): void
+    {
+        $this->assertTrue(isset($this->getMockCommand()->prepareArguments($this->getMockArray())['flags']));
+        $this->assertTrue(isset($this->getMockCommand()->prepareArguments($this->getMockArray())['options']));
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayAtIndex_flags(): void
+    {
+        $this->assertTrue(is_array($this->getMockCommand()->prepareArguments($this->getMockArray())['flags']));
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayWhoseKeysAreStringsAtIndex_flags():void
+    {
+        $this->assertTrue($this->keysAreStrings($this->getMockCommand()->prepareArguments($this->getMockArray())['flags']));
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayWhoseValuesAreArraysAtIndex_flags():void
+    {
+        $flagsArray = $this->getMockCommand()->prepareArguments($this->getMockArray())['flags'];
+        foreach($flagsArray as $flagArray) {
+            $this->assertTrue(is_array($flagArray));
+        }
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayOfArraysWhoseKeysAreIntsAtIndex_flags():void
+    {
+
+        $flagsArray = $this->getMockCommand()->prepareArguments($this->getMockArray())['flags'];
+        foreach($flagsArray as $flagArray) {
+            foreach($flagArray as $key => $value) {
+                $this->assertTrue(is_int($key));
+            }
+        }
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayOfArraysWhoseValuesAreStringsAtIndex_flags():void
+    {
+        $flagsArray = $this->getMockCommand()->prepareArguments($this->getMockArray())['flags'];
+        foreach($flagsArray as $flagArray) {
+            foreach($flagArray as $value) {
+                $this->assertTrue(is_string($value));
+            }
+        }
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayAtIndex_options(): void
+    {
+        $this->assertTrue(is_array($this->getMockCommand()->prepareArguments($this->getMockArray())['options']));
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayWhoseKeysAreIntsAtIndex_options():void
+    {
+        $this->assertTrue($this->keysAreInts($this->getMockCommand()->prepareArguments($this->getMockArray())['options']));
+    }
+
+    public function testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayWhoseValuesAreStringsAtIndex_options():void
+    {
+        $flagsArray = $this->getMockCommand()->prepareArguments($this->getMockArray())['options'];
+        foreach($flagsArray as $flagArray) {
+            $this->assertTrue(is_string($flagArray));
+        }
+    }
+
+
+    /**
+     * @param array<mixed> $array
+     *
+     * @return bool True if all keys in array are ints, or if array is empty, false otherwise.
+     */
+    private function keysAreInts(array $array, bool $recurse = false): bool
+    {
+        if(empty($array)) { return true; }
+        $status = [];
+        foreach($array as $key => $value) {
+            array_push($status, is_int($key));
+            if(is_array($value) && !empty($value)) {
+                if($recurse === true) {
+                    array_push($status, $this->keysAreInts($value, true));
+                }
+                continue;
+            }
+        }
+        return !in_array(false, $status);
+    }
+
+
+    /**
+     * @param array<mixed> $array
+     *
+     * @return bool True if all keys in array are strings, or if array is empty, false otherwise.
+     */
+    private function keysAreStrings(array $array, bool $recurse = false): bool
+    {
+        if(empty($array)) { return true; }
+        $status = [];
+        foreach($array as $key => $value) {
+            array_push($status, is_string($key));
+            if(is_array($value) && !empty($value)) {
+                if($recurse === true) {
+                    array_push($status, $this->keysAreStrings($value, true));
+                }
+                continue;
+            }
+        }
+        return !in_array(false, $status);
+    }
+
+    /**
+     * @param mixed $needle A values to search for.
+     * @param array<mixed> $haystack An array of values to be interpreted as arguments.
+     */
+    private function in_array_recursive(mixed $needle, array $haystack): bool
+    {
+        foreach($haystack as $value) {
+            if($value === $needle) {
+                return true;
+            }
+            if (is_array($value) && $this->in_array_recursive($needle, $value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+
+    /**
+     * Verify that all keys in a given array are type int or string.
+     *
+     * @param array<mixed> $array An array of values to be interpreted as arguments.
+     *
+     * @retrun True if all keys are type int or string, false otherwise.
+     */
+    private function valuesAreStringsOrArrays(array $array): bool
+    {
+        $status = [];
+        foreach($array as $key => $value) {
+            if(!is_string($value) && !is_int($value)) {
+                array_push($status, false);
+            }
+            if(is_array($value)) {
+                array_push($status, $this->valuesAreStringsOrArrays($value));
+            }
+        }
+        return !in_array(false, $status);
+    }
+
+    private function getMockCommand(): DDMSCommand
+    {
+        return $this->getMockBuilder(DDMSCommand::class)->getMockForAbstractClass();
+    }
+
+    /**
+     * @return array<mixed> $array An array of values to be interpreted as arguments.
+     */
+    private function getMockArray(): array
+    {
+        $arrays = [
+            ['OPTION', '--flag', ['arg1', 'arg2'], null, '--flag' => 'arg1'],
+            ['OPTION', rand(0, PHP_INT_MAX), '--flag', [[],'arg1' => ['bazzer'], 'arg2'], false, 'stringkey' => 'value'],
+            ['OPTIONA', 'OPTIONB', 'OPTIONC', '--flag' => ['arg1', 'arg2'], '--flag2', null, false, true]
+        ];
+        return $arrays[array_rand($arrays)];
+    }
+}
+

--- a/tests/command/AbstractCommandTest.php
+++ b/tests/command/AbstractCommandTest.php
@@ -3,7 +3,7 @@
 namespace tests\command\AbstractCommand;
 
 use PHPUnit\Framework\TestCase;
-use ddms\abstractions\command\AbstractCommand as DDMSCommand;
+use ddms\abstractions\command\AbstractCommand;
 
 final class AbstractCommandTest extends TestCase
 {
@@ -160,9 +160,9 @@ final class AbstractCommandTest extends TestCase
         return !in_array(false, $status);
     }
 
-    private function getMockCommand(): DDMSCommand
+    private function getMockCommand(): AbstractCommand
     {
-        return $this->getMockBuilder(DDMSCommand::class)->getMockForAbstractClass();
+        return $this->getMockBuilder(AbstractCommand::class)->getMockForAbstractClass();
     }
 
     /**

--- a/tests/command/AbstractCommandTest.php
+++ b/tests/command/AbstractCommandTest.php
@@ -76,7 +76,6 @@ final class AbstractCommandTest extends TestCase
         }
     }
 
-
     /**
      * @param array<mixed> $array
      *
@@ -136,8 +135,6 @@ final class AbstractCommandTest extends TestCase
         }
         return false;
     }
-
-
 
     /**
      * Verify that all keys in a given array are type int or string.

--- a/tests/command/AbstractCommandTest.php
+++ b/tests/command/AbstractCommandTest.php
@@ -144,7 +144,7 @@ final class AbstractCommandTest extends TestCase
      *
      * @param array<mixed> $array An array of values to be interpreted as arguments.
      *
-     * @retrun True if all keys are type int or string, false otherwise.
+     * @return bool True if all keys are type int or string, false otherwise.
      */
     private function valuesAreStringsOrArrays(array $array): bool
     {

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -11,10 +11,21 @@ final class AbstractDDMSTest extends TestCase
 {
     public function testRunCommandReturnsValueMatchingValueReturnedOnIndependantCallToSpecifiedCommandsRunMethod(): void
     {
+        $this->assertEquals(
+            $this->getMockCommand()->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments([])),
+            $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(), [])
+        );
+    }
 
-        $mockUserInterface = $this->getMockBuilder(AbstractUserInterface::class)
+    private function getMockUserInterface(): AbstractUserInterface
+    {
+        return $this->getMockBuilder(AbstractUserInterface::class)
             ->getMockForAbstractClass();
 
+    }
+
+    private function getMockCommand(): AbstractCommand
+    {
         $mockCommand = $this->getMockBuilder(AbstractCommand::class)
             ->setMethods(['run'])
             ->getMockForAbstractClass();
@@ -23,12 +34,14 @@ final class AbstractDDMSTest extends TestCase
             ->method('run')
             ->willReturn(true);
 
-        $mockDDMS = $this->getMockBuilder(AbstractDDMS::class)
-            ->getMockForAbstractClass();
+        return $mockCommand;
 
-        $this->assertEquals(
-            $mockCommand->run($mockUserInterface, $mockCommand->prepareArguments([])),
-            $mockDDMS->runCommand($mockUserInterface, $mockCommand, [])
-        );
     }
+
+    private function getMockDDMS(): AbstractDDMS
+    {
+        return $this->getMockBuilder(AbstractDDMS::class)
+            ->getMockForAbstractClass();
+    }
+
 }

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -12,7 +12,7 @@ use ddms\abstractions\command\AbstractCommand;
 final class AbstractDDMSTest extends TestCase
 {
 
-    public const MOCK_COMMAND_UI_OUTPUT = 'Testing';
+    private const MOCK_COMMAND_UI_OUTPUT = 'Testing';
 
     public function testRunCommandReturnsValueMatchingValueReturnedOnIndependantCallToSpecifiedCommandsRunMethod(): void
     {
@@ -22,11 +22,19 @@ final class AbstractDDMSTest extends TestCase
         );
     }
 
+    /**
+     * @return array<mixed>
+     */
+    private function mockArgvArrayWithFlagsAndOptions(): array
+    {
+        return ['mockOutput', '--output', self::MOCK_COMMAND_UI_OUTPUT];
+    }
+
     public function testRunCommandOutputMatchesOutputOfIndpendantCallToSpecifiedCommandsRunMethod(): void
     {
         $this->expectOutputString(self::MOCK_COMMAND_UI_OUTPUT . self::MOCK_COMMAND_UI_OUTPUT);
-        $this->getMockCommand()->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments(['mockOutput']));
-        $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(), ['mockOutput']);
+        $this->getMockCommand()->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments($this->mockArgvArrayWithFlagsAndOptions()));
+        $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(), $this->mockArgvArrayWithFlagsAndOptions());
     }
 
     private function getMockUserInterface(): AbstractUserInterface
@@ -62,8 +70,8 @@ final class MockCommand extends AbstractCommand implements Command
 
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
-        if(in_array('mockOutput', $preparedArguments['options'])) {
-            $userInterface->showMessage(AbstractDDMSTest::MOCK_COMMAND_UI_OUTPUT);
+        if(in_array('mockOutput', $preparedArguments['options']) && isset($preparedArguments['flags']['output'][0])) {
+            $userInterface->showMessage($preparedArguments['flags']['output'][0]);
         }
         return true;
     }

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\command\AbstractCommand;
+namespace tests\command;
 
 use PHPUnit\Framework\TestCase;
 use ddms\interfaces\command\Command;
@@ -49,12 +49,6 @@ final class AbstractDDMSTest extends TestCase
 
         return new MockCommand();
 
-    }
-
-    private function mockRunMethod(bool $mockOutput = false): bool
-    {
-        if($mockOutput === true) { echo self::MOCK_COMMAND_UI_OUTPUT; }
-        return true;
     }
 
     private function getMockDDMS(): AbstractDDMS

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -13,19 +13,18 @@ final class AbstractDDMSTest extends TestCase
     {
 
         $mockUserInterface = $this->getMockBuilder(DDMSUserInterface::class)
-            ->getMock();
+            ->getMockForAbstractClass();
 
         $mockCommand = $this->getMockBuilder(DDMSCommand::class)
             ->setMethods(['run'])
-            ->getMock();
+            ->getMockForAbstractClass();
 
-        $mockCommand->method('run')
+        $mockCommand
+            ->method('run')
             ->willReturn(true);
 
-        $mockDDMS = $this->getMockForAbstractClass(DDMS::class);
-        $mockDDMS->expects($this->any())->method('run')
-            ->will($this->returnValue(false)
-        );
+        $mockDDMS = $this->getMockBuilder(DDMS::class)
+            ->getMockForAbstractClass();
 
         $this->assertEquals(
             $mockCommand->run($mockUserInterface, $mockCommand->prepareArguments([])),

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -9,12 +9,22 @@ use ddms\abstractions\command\AbstractCommand;
 
 final class AbstractDDMSTest extends TestCase
 {
+
+    private const MOCK_COMMAND_UI_OUTPUT = 'Testing';
+
     public function testRunCommandReturnsValueMatchingValueReturnedOnIndependantCallToSpecifiedCommandsRunMethod(): void
     {
         $this->assertEquals(
             $this->getMockCommand()->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments([])),
             $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(), [])
         );
+    }
+
+    public function testRunCommandOutputMatchesOutputOfIndpendantCallToSpecifiedCommandsRunMethod(): void
+    {
+        $this->expectOutputString(self::MOCK_COMMAND_UI_OUTPUT . self::MOCK_COMMAND_UI_OUTPUT);
+        $this->getMockCommand(true)->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments([]));
+        $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(true), []);
     }
 
     private function getMockUserInterface(): AbstractUserInterface
@@ -24,7 +34,7 @@ final class AbstractDDMSTest extends TestCase
 
     }
 
-    private function getMockCommand(): AbstractCommand
+    private function getMockCommand(bool $mockOutput = false): AbstractCommand
     {
         $mockCommand = $this->getMockBuilder(AbstractCommand::class)
             ->setMethods(['run'])
@@ -32,10 +42,18 @@ final class AbstractDDMSTest extends TestCase
 
         $mockCommand
             ->method('run')
-            ->willReturn(true);
+            ->will($this->returnValue(
+                $this->mockRunMethod($mockOutput)
+            ));
 
         return $mockCommand;
 
+    }
+
+    private function mockRunMethod(bool $mockOutput = false): bool
+    {
+        if($mockOutput === true) { echo self::MOCK_COMMAND_UI_OUTPUT; }
+        return true;
     }
 
     private function getMockDDMS(): AbstractDDMS

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -3,19 +3,19 @@
 namespace tests\command\AbstractCommand;
 
 use PHPUnit\Framework\TestCase;
-use ddms\abstractions\command\AbstractDDMS as DDMS;
-use ddms\abstractions\ui\AbstractUserInterface as DDMSUserInterface;
-use ddms\abstractions\command\AbstractCommand as DDMSCommand;
+use ddms\abstractions\command\AbstractDDMS;
+use ddms\abstractions\ui\AbstractUserInterface;
+use ddms\abstractions\command\AbstractCommand;
 
 final class AbstractDDMSTest extends TestCase
 {
     public function testRunCommandReturnsValueMatchingValueReturnedOnIndependantCallToSpecifiedCommandsRunMethod(): void
     {
 
-        $mockUserInterface = $this->getMockBuilder(DDMSUserInterface::class)
+        $mockUserInterface = $this->getMockBuilder(AbstractUserInterface::class)
             ->getMockForAbstractClass();
 
-        $mockCommand = $this->getMockBuilder(DDMSCommand::class)
+        $mockCommand = $this->getMockBuilder(AbstractCommand::class)
             ->setMethods(['run'])
             ->getMockForAbstractClass();
 
@@ -23,7 +23,7 @@ final class AbstractDDMSTest extends TestCase
             ->method('run')
             ->willReturn(true);
 
-        $mockDDMS = $this->getMockBuilder(DDMS::class)
+        $mockDDMS = $this->getMockBuilder(AbstractDDMS::class)
             ->getMockForAbstractClass();
 
         $this->assertEquals(

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -22,19 +22,19 @@ final class AbstractDDMSTest extends TestCase
         );
     }
 
+    public function testRunCommandOutputMatchesOutputOfIndpendantCallToSpecifiedCommandsRunMethod(): void
+    {
+        $this->expectOutputString(self::MOCK_COMMAND_UI_OUTPUT . self::MOCK_COMMAND_UI_OUTPUT);
+        $this->getMockCommand()->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments($this->mockArgvArrayWithFlagsAndOptions()));
+        $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(), $this->mockArgvArrayWithFlagsAndOptions());
+    }
+
     /**
      * @return array<mixed>
      */
     private function mockArgvArrayWithFlagsAndOptions(): array
     {
         return ['mockOutput', '--output', self::MOCK_COMMAND_UI_OUTPUT];
-    }
-
-    public function testRunCommandOutputMatchesOutputOfIndpendantCallToSpecifiedCommandsRunMethod(): void
-    {
-        $this->expectOutputString(self::MOCK_COMMAND_UI_OUTPUT . self::MOCK_COMMAND_UI_OUTPUT);
-        $this->getMockCommand()->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments($this->mockArgvArrayWithFlagsAndOptions()));
-        $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(), $this->mockArgvArrayWithFlagsAndOptions());
     }
 
     private function getMockUserInterface(): AbstractUserInterface

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -3,6 +3,8 @@
 namespace tests\command\AbstractCommand;
 
 use PHPUnit\Framework\TestCase;
+use ddms\interfaces\command\Command;
+use ddms\interfaces\ui\UserInterface;
 use ddms\abstractions\command\AbstractDDMS;
 use ddms\abstractions\ui\AbstractUserInterface;
 use ddms\abstractions\command\AbstractCommand;
@@ -10,7 +12,7 @@ use ddms\abstractions\command\AbstractCommand;
 final class AbstractDDMSTest extends TestCase
 {
 
-    private const MOCK_COMMAND_UI_OUTPUT = 'Testing';
+    public const MOCK_COMMAND_UI_OUTPUT = 'Testing';
 
     public function testRunCommandReturnsValueMatchingValueReturnedOnIndependantCallToSpecifiedCommandsRunMethod(): void
     {
@@ -23,8 +25,8 @@ final class AbstractDDMSTest extends TestCase
     public function testRunCommandOutputMatchesOutputOfIndpendantCallToSpecifiedCommandsRunMethod(): void
     {
         $this->expectOutputString(self::MOCK_COMMAND_UI_OUTPUT . self::MOCK_COMMAND_UI_OUTPUT);
-        $this->getMockCommand(true)->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments([]));
-        $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(true), []);
+        $this->getMockCommand()->run($this->getMockUserInterface(), $this->getMockCommand()->prepareArguments(['mockOutput']));
+        $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockCommand(), ['mockOutput']);
     }
 
     private function getMockUserInterface(): AbstractUserInterface
@@ -34,19 +36,10 @@ final class AbstractDDMSTest extends TestCase
 
     }
 
-    private function getMockCommand(bool $mockOutput = false): AbstractCommand
+    private function getMockCommand(): AbstractCommand
     {
-        $mockCommand = $this->getMockBuilder(AbstractCommand::class)
-            ->setMethods(['run'])
-            ->getMockForAbstractClass();
 
-        $mockCommand
-            ->method('run')
-            ->will($this->returnValue(
-                $this->mockRunMethod($mockOutput)
-            ));
-
-        return $mockCommand;
+        return new MockCommand();
 
     }
 
@@ -60,6 +53,19 @@ final class AbstractDDMSTest extends TestCase
     {
         return $this->getMockBuilder(AbstractDDMS::class)
             ->getMockForAbstractClass();
+    }
+
+}
+
+final class MockCommand extends AbstractCommand implements Command
+{
+
+    public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
+    {
+        if(in_array('mockOutput', $preparedArguments['options'])) {
+            echo AbstractDDMSTest::MOCK_COMMAND_UI_OUTPUT;
+        }
+        return true;
     }
 
 }

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -63,7 +63,7 @@ final class MockCommand extends AbstractCommand implements Command
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
         if(in_array('mockOutput', $preparedArguments['options'])) {
-            echo AbstractDDMSTest::MOCK_COMMAND_UI_OUTPUT;
+            $userInterface->showMessage(AbstractDDMSTest::MOCK_COMMAND_UI_OUTPUT);
         }
         return true;
     }

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -12,16 +12,20 @@ final class AbstractDDMSTest extends TestCase
     public function testRunCommandReturnsValueMatchingValueReturnedOnIndependantCallToSpecifiedCommandsRunMethod(): void
     {
 
+        $mockUserInterface = $this->getMockBuilder(DDMSUserInterface::class)
+            ->getMock();
+
         $mockCommand = $this->getMockBuilder(DDMSCommand::class)
             ->setMethods(['run'])
             ->getMock();
 
-        $mockDDMS = $this->getMockBuilder(DDMS::class)
-            ->setMethods(['run'])
-            ->getMock();
+        $mockCommand->method('run')
+            ->willReturn(true);
 
-        $mockUserInterface = $this->getMockBuilder(DDMSUserInterface::class)
-            ->getMock();
+        $mockDDMS = $this->getMockForAbstractClass(DDMS::class);
+        $mockDDMS->expects($this->any())->method('run')
+            ->will($this->returnValue(false)
+        );
 
         $this->assertEquals(
             $mockCommand->run($mockUserInterface, $mockCommand->prepareArguments([])),

--- a/tests/command/AbstractDDMSTest.php
+++ b/tests/command/AbstractDDMSTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace tests\command\AbstractCommand;
+
+use PHPUnit\Framework\TestCase;
+use ddms\abstractions\command\AbstractDDMS as DDMS;
+use ddms\abstractions\ui\AbstractUserInterface as DDMSUserInterface;
+use ddms\abstractions\command\AbstractCommand as DDMSCommand;
+
+final class AbstractDDMSTest extends TestCase
+{
+    public function testRunCommandReturnsValueMatchingValueReturnedOnIndependantCallToSpecifiedCommandsRunMethod(): void
+    {
+
+        $mockCommand = $this->getMockBuilder(DDMSCommand::class)
+            ->setMethods(['run'])
+            ->getMock();
+
+        $mockDDMS = $this->getMockBuilder(DDMS::class)
+            ->setMethods(['run'])
+            ->getMock();
+
+        $mockUserInterface = $this->getMockBuilder(DDMSUserInterface::class)
+            ->getMock();
+
+        $this->assertEquals(
+            $mockCommand->run($mockUserInterface, $mockCommand->prepareArguments([])),
+            $mockDDMS->runCommand($mockUserInterface, $mockCommand, [])
+        );
+    }
+}

--- a/tests/command/DDMSHelpTest.php
+++ b/tests/command/DDMSHelpTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace tests\command\AbstractCommand;
+
+use PHPUnit\Framework\TestCase;
+use ddms\classes\command\DDMSHelp as DDMSCommand;
+
+final class DDMSHelpTest extends TestCase
+{
+
+    public function testTest(): void {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/command/DDMSHelpTest.php
+++ b/tests/command/DDMSHelpTest.php
@@ -9,9 +9,22 @@ use ddms\classes\ui\CommandLineUI as DDMSUserInterface;
 final class DDMSHelpTest extends TestCase
 {
 
-    public function testRunOutputsHelpFile_Help_IfNoFlagsOrOptionsAreSpecified(): void {
+    public function testRunOutputsHelpFile_Help_IfNoFlagsOrOptionsAreSpecified(): void
+    {
         $this->expectOutputString($this->expectedOutput('help'));
         $this->getMockCommand()->run(new DDMSUserInterface());
+    }
+
+    public function testRunOutputsEmptyStringIfFlagsAreSpecifiedAndHelpFlagIsNotPresent(): void
+    {
+        $this->expectOutputString('');
+        $this->getMockCommand()->run(new DDMSUserInterface(), ['flags' => ['flag' => []], 'options' => []]);
+    }
+
+    public function testRunOutputsHelpFile_Help_IfHelpFlagIsTheOnlyFlagSpecifiedAndHasNoArguments(): void
+    {
+        $this->expectOutputString($this->expectedOutput('help'));
+        $this->getMockCommand()->run(new DDMSUserInterface(), ['flags' => ['help' => []], 'options' => []]);
     }
 
     private function expectedHelpFileOutput(string $helpFlagName): string

--- a/tests/command/DDMSHelpTest.php
+++ b/tests/command/DDMSHelpTest.php
@@ -3,12 +3,53 @@
 namespace tests\command\AbstractCommand;
 
 use PHPUnit\Framework\TestCase;
-use ddms\classes\command\DDMSHelp as DDMSCommand;
+use ddms\classes\command\DDMSHelp as DDMSHelpCommand;
+use ddms\classes\ui\CommandLineUI as DDMSUserInterface;
 
 final class DDMSHelpTest extends TestCase
 {
 
-    public function testTest(): void {
-        $this->assertTrue(true);
+    public function testRunOutputsHelpFile_Help_IfNoFlagsOrOptionsAreSpecified(): void {
+        $this->expectOutputString($this->expectedOutput('help'));
+        $this->getMockCommand()->run(new DDMSUserInterface());
     }
+
+    private function expectedHelpFileOutput(string $helpFlagName): string
+    {
+        if(file_exists($this->expectedHelpFilePath($helpFlagName)))
+        {
+            $output = file_get_contents($this->expectedHelpFilePath($helpFlagName));
+        }
+        return (isset($output) && is_string($output) ? PHP_EOL . "\e[0m\e[45m\e[30m" . $output . "\e[0m" . PHP_EOL : '');
+    }
+
+    private function expectedHelpFilePath(string $helpFlagName): string
+    {
+        return str_replace('tests/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
+    }
+
+    private function getMockCommand(): DDMSHelpCommand
+    {
+        return new DDMSHelpCommand();
+    }
+
+    private function expectedOutput(string $helpFlagName): string
+    {
+         return sprintf(
+            "%s%s%s%s%s%s%s%s%s%s%s",
+            PHP_EOL,
+            "\e[0m\e[105m\e[30m    ",
+            "\e[0m\e[92m " . date('Y-m-d @ H:i:s') . "  \e[0m ",
+            "\e[0m\e[102m\e[30m" . 'help' . "\e[0m\e[105m\e[30m    \e[0m",
+            PHP_EOL,
+            PHP_EOL,
+            "\e[0m\e[107m\e[30m",
+            $this->expectedHelpFileOutput($helpFlagName),
+            "\e[0m",
+            PHP_EOL,
+            PHP_EOL,
+        );
+
+    }
+
 }

--- a/tests/command/DDMSTest.php
+++ b/tests/command/DDMSTest.php
@@ -27,6 +27,27 @@ final class DDMSTest extends TestCase
         $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockDDMSCommand(), $this->mockArgvArrayWithFlagsAndOptions());
     }
 
+    private function determineHelpFilePath(string $helpFlagName): string
+    {
+        return str_replace('tests/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
+    }
+
+    public function testRunCommandReturnValueAndOutputMatchesReturnValueAndOutputOfIndpendantCallToRunMethodOfCommandThatCorrespondsToFirstFlag(): void
+    {
+        $helpCommand = new Help();
+        $ddms = $this->getMockDDMS();
+        $ui = $this->getMockUserInterface();
+        $argv = ['--help'];
+        $this->expectOutputString(
+            PHP_EOL . file_get_contents($this->determineHelpFilePath('help')) . PHP_EOL .
+            PHP_EOL . file_get_contents($this->determineHelpFilePath('help')) . PHP_EOL
+        );
+        $this->assertEquals(
+            $helpCommand->run($ui, $helpCommand->prepareArguments($argv)),
+            $ddms->run($ui, $ddms->prepareArguments($argv))
+        );
+    }
+
     public function testRunThrowsARuntimeExceptionIfFlagsAreSpecifiedAndFirstFlagDoesNotCorrespondToAnExistingCommand(): void
     {
         $ddms = $this->getMockDDMS();

--- a/tests/command/DDMSTest.php
+++ b/tests/command/DDMSTest.php
@@ -9,6 +9,7 @@ use ddms\abstractions\command\AbstractCommand;
 use ddms\abstractions\ui\AbstractUserInterface;
 use ddms\interfaces\ui\UserInterface;
 use ddms\interfaces\command\Command;
+use \RuntimeException;
 
 final class DDMSTest extends TestCase
 {
@@ -25,6 +26,15 @@ final class DDMSTest extends TestCase
         $this->getMockDDMSCommand()->run($this->getMockUserInterface(), $this->getMockDDMSCommand()->prepareArguments($this->mockArgvArrayWithFlagsAndOptions()));
         $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockDDMSCommand(), $this->mockArgvArrayWithFlagsAndOptions());
     }
+
+    public function testRunThrowsARuntimeExceptionIfFlagsAreSpecifiedAndFirstFlagDoesNotCorrespondToAnExistingCommand(): void
+    {
+        $ddms = $this->getMockDDMS();
+        $this->expectException(RuntimeException::class);
+        $ddms->run($this->getMockUserInterface(), $ddms->prepareArguments(['--command-does-not-exist', 'flagArg1', 'flagArg2']));
+    }
+
+   # NOTE: need testDDMSPrepareArgsReturnsValueMatchingIndependantCallToRelevantCommandsPrepareArgsIfFirstFlagSpecifiedCorrespondsToAnExistingCommand(): void
 
     private function getMockDDMSCommand(): AbstractCommand
     {

--- a/tests/command/DDMSTest.php
+++ b/tests/command/DDMSTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace tests\command;
+
+use PHPUnit\Framework\TestCase;
+use ddms\classes\command\Help;
+use ddms\classes\command\DDMS;
+use ddms\abstractions\command\AbstractCommand;
+use ddms\abstractions\ui\AbstractUserInterface;
+use ddms\interfaces\ui\UserInterface;
+use ddms\interfaces\command\Command;
+
+final class DDMSTest extends TestCase
+{
+
+    private const MOCK_COMMAND_UI_OUTPUT = 'Testing';
+
+    public function testRunCommandReturnValueAndOutputMatchesReturnValueAndOutputOfIndpendantCallToSpecifiedCommandsRunMethod(): void
+    {
+        $this->assertEquals(
+            $this->getMockDDMSCommand()->run($this->getMockUserInterface(), $this->getMockDDMSCommand()->prepareArguments([])),
+            $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockDDMSCommand(), [])
+        );
+        $this->expectOutputString(self::MOCK_COMMAND_UI_OUTPUT . self::MOCK_COMMAND_UI_OUTPUT);
+        $this->getMockDDMSCommand()->run($this->getMockUserInterface(), $this->getMockDDMSCommand()->prepareArguments($this->mockArgvArrayWithFlagsAndOptions()));
+        $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockDDMSCommand(), $this->mockArgvArrayWithFlagsAndOptions());
+    }
+
+    private function getMockDDMSCommand(): AbstractCommand
+    {
+
+        return new MockDDMSCommand();
+
+    }
+
+    private function getMockUserInterface(): AbstractUserInterface
+    {
+        return $this->getMockBuilder(AbstractUserInterface::class)
+            ->getMockForAbstractClass();
+
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function mockArgvArrayWithFlagsAndOptions(): array
+    {
+        return ['mockOutput', '--output', self::MOCK_COMMAND_UI_OUTPUT];
+    }
+
+    private function getMockDDMS(): DDMS
+    {
+        return new DDMS();
+    }
+
+}
+
+final class MockDDMSCommand extends AbstractCommand implements Command
+{
+
+    public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
+    {
+        if(in_array('mockOutput', $preparedArguments['options']) && isset($preparedArguments['flags']['output'][0])) {
+            $userInterface->showMessage($preparedArguments['flags']['output'][0]);
+        }
+        return true;
+    }
+
+}

--- a/tests/command/HelpTest.php
+++ b/tests/command/HelpTest.php
@@ -12,19 +12,19 @@ final class HelpTest extends TestCase
     public function testRunOutputsHelpFile_Help_IfNoFlagsOrOptionsAreSpecified(): void
     {
         $this->expectOutputString($this->expectedOutput('help'));
-        $this->getMockCommand()->run(new DDMSUserInterface());
+        $this->getMockHelpCommand()->run(new DDMSUserInterface());
     }
 
     public function testRunOutputsEmptyStringIfFlagsAreSpecifiedAndHelpFlagIsNotPresent(): void
     {
         $this->expectOutputString('');
-        $this->getMockCommand()->run(new DDMSUserInterface(), ['flags' => ['flag' => []], 'options' => []]);
+        $this->getMockHelpCommand()->run(new DDMSUserInterface(), ['flags' => ['flag' => []], 'options' => []]);
     }
 
     public function testRunOutputsHelpFile_Help_IfHelpFlagIsTheOnlyFlagSpecifiedAndHasNoArguments(): void
     {
         $this->expectOutputString($this->expectedOutput('help'));
-        $this->getMockCommand()->run(new DDMSUserInterface(), ['flags' => ['help' => []], 'options' => []]);
+        $this->getMockHelpCommand()->run(new DDMSUserInterface(), ['flags' => ['help' => []], 'options' => []]);
     }
 
     private function expectedHelpFileOutput(string $helpFlagName): string
@@ -41,7 +41,7 @@ final class HelpTest extends TestCase
         return str_replace('tests/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
     }
 
-    private function getMockCommand(): HelpCommand
+    private function getMockHelpCommand(): HelpCommand
     {
         return new HelpCommand();
     }

--- a/tests/command/HelpTest.php
+++ b/tests/command/HelpTest.php
@@ -33,7 +33,7 @@ final class HelpTest extends TestCase
         {
             $output = file_get_contents($this->expectedHelpFilePath($helpFlagName));
         }
-        return (isset($output) && is_string($output) ? PHP_EOL . "\e[0m\e[45m\e[30m" . $output . "\e[0m" . PHP_EOL : '');
+        return (isset($output) && is_string($output) ? PHP_EOL . $output . PHP_EOL : '');
     }
 
     private function expectedHelpFilePath(string $helpFlagName): string

--- a/tests/command/HelpTest.php
+++ b/tests/command/HelpTest.php
@@ -3,8 +3,8 @@
 namespace tests\command\AbstractCommand;
 
 use PHPUnit\Framework\TestCase;
-use ddms\classes\command\Help as HelpCommand;
-use ddms\classes\ui\CommandLineUI as DDMSUserInterface;
+use ddms\classes\command\Help;
+use ddms\classes\ui\CommandLineUI;
 
 final class HelpTest extends TestCase
 {
@@ -12,19 +12,19 @@ final class HelpTest extends TestCase
     public function testRunOutputsHelpFile_Help_IfNoFlagsOrOptionsAreSpecified(): void
     {
         $this->expectOutputString($this->expectedOutput('help'));
-        $this->getMockHelpCommand()->run(new DDMSUserInterface());
+        $this->getMockHelp()->run(new CommandLineUI());
     }
 
     public function testRunOutputsEmptyStringIfFlagsAreSpecifiedAndHelpFlagIsNotPresent(): void
     {
         $this->expectOutputString('');
-        $this->getMockHelpCommand()->run(new DDMSUserInterface(), ['flags' => ['flag' => []], 'options' => []]);
+        $this->getMockHelp()->run(new CommandLineUI(), ['flags' => ['flag' => []], 'options' => []]);
     }
 
     public function testRunOutputsHelpFile_Help_IfHelpFlagIsTheOnlyFlagSpecifiedAndHasNoArguments(): void
     {
         $this->expectOutputString($this->expectedOutput('help'));
-        $this->getMockHelpCommand()->run(new DDMSUserInterface(), ['flags' => ['help' => []], 'options' => []]);
+        $this->getMockHelp()->run(new CommandLineUI(), ['flags' => ['help' => []], 'options' => []]);
     }
 
     private function expectedHelpFileOutput(string $helpFlagName): string
@@ -41,9 +41,9 @@ final class HelpTest extends TestCase
         return str_replace('tests/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
     }
 
-    private function getMockHelpCommand(): HelpCommand
+    private function getMockHelp(): Help
     {
-        return new HelpCommand();
+        return new Help();
     }
 
     private function expectedOutput(string $helpFlagName): string

--- a/tests/command/HelpTest.php
+++ b/tests/command/HelpTest.php
@@ -11,20 +11,20 @@ final class HelpTest extends TestCase
 
     public function testRunOutputsHelpFile_Help_IfNoFlagsOrOptionsAreSpecified(): void
     {
-        $this->expectOutputString($this->expectedOutput('help'));
-        $this->getMockHelp()->run(new CommandLineUI());
+        $this->expectOutputString($this->expectedHelpFileOutput('help'));
+        $this->getHelpInstance()->run(new CommandLineUI());
     }
 
     public function testRunOutputsEmptyStringIfFlagsAreSpecifiedAndHelpFlagIsNotPresent(): void
     {
         $this->expectOutputString('');
-        $this->getMockHelp()->run(new CommandLineUI(), ['flags' => ['flag' => []], 'options' => []]);
+        $this->getHelpInstance()->run(new CommandLineUI(), ['flags' => ['flag' => []], 'options' => []]);
     }
 
-    public function testRunOutputsHelpFile_Help_IfHelpFlagIsTheOnlyFlagSpecifiedAndHasNoArguments(): void
+    public function testRunOutputsHelpFile_Help_IfHelpFlagIsSpecifiedAndHasNoArguments(): void
     {
-        $this->expectOutputString($this->expectedOutput('help'));
-        $this->getMockHelp()->run(new CommandLineUI(), ['flags' => ['help' => []], 'options' => []]);
+        $this->expectOutputString($this->expectedHelpFileOutput('help'));
+        $this->getHelpInstance()->run(new CommandLineUI(), ['flags' => ['help' => [], 'flag' => []], 'options' => []]);
     }
 
     private function expectedHelpFileOutput(string $helpFlagName): string
@@ -41,15 +41,9 @@ final class HelpTest extends TestCase
         return str_replace('tests/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
     }
 
-    private function getMockHelp(): Help
+    private function getHelpInstance(): Help
     {
         return new Help();
-    }
-
-    private function expectedOutput(string $helpFlagName): string
-    {
-         return $this->expectedHelpFileOutput($helpFlagName);
-
     }
 
 }

--- a/tests/command/HelpTest.php
+++ b/tests/command/HelpTest.php
@@ -48,20 +48,7 @@ final class HelpTest extends TestCase
 
     private function expectedOutput(string $helpFlagName): string
     {
-         return sprintf(
-            "%s%s%s%s%s%s%s%s%s%s%s",
-            PHP_EOL,
-            "\e[0m\e[105m\e[30m    ",
-            "\e[0m\e[92m " . date('Y-m-d @ H:i:s') . "  \e[0m ",
-            "\e[0m\e[102m\e[30m" . 'help' . "\e[0m\e[105m\e[30m    \e[0m",
-            PHP_EOL,
-            PHP_EOL,
-            "\e[0m\e[107m\e[30m",
-            $this->expectedHelpFileOutput($helpFlagName),
-            "\e[0m",
-            PHP_EOL,
-            PHP_EOL,
-        );
+         return $this->expectedHelpFileOutput($helpFlagName);
 
     }
 

--- a/tests/command/HelpTest.php
+++ b/tests/command/HelpTest.php
@@ -3,10 +3,10 @@
 namespace tests\command\AbstractCommand;
 
 use PHPUnit\Framework\TestCase;
-use ddms\classes\command\DDMSHelp as DDMSHelpCommand;
+use ddms\classes\command\Help as HelpCommand;
 use ddms\classes\ui\CommandLineUI as DDMSUserInterface;
 
-final class DDMSHelpTest extends TestCase
+final class HelpTest extends TestCase
 {
 
     public function testRunOutputsHelpFile_Help_IfNoFlagsOrOptionsAreSpecified(): void
@@ -41,9 +41,9 @@ final class DDMSHelpTest extends TestCase
         return str_replace('tests/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
     }
 
-    private function getMockCommand(): DDMSHelpCommand
+    private function getMockCommand(): HelpCommand
     {
-        return new DDMSHelpCommand();
+        return new HelpCommand();
     }
 
     private function expectedOutput(string $helpFlagName): string

--- a/tests/factory/CommandFactoryTest.php
+++ b/tests/factory/CommandFactoryTest.php
@@ -12,12 +12,6 @@ final class CommandFactoryTest extends TestCase
 
     public function testGetCommandInstanceReturnsHelpInstanceIfClassCorrespondingToSpecifiedCommandNameDoesNotExist(): void {
         $commandName = $this->getRandomName();
-        $this->expectOutputString(
-            CommandFactory::class .
-            "Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" .
-            $commandName .
-            "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`."
-        );
         $this->assertTrue(
             $this->getCommandFactoryInstance()->getCommandInstance($commandName, new CommandLineUI())
             instanceof Help

--- a/tests/factory/CommandFactoryTest.php
+++ b/tests/factory/CommandFactoryTest.php
@@ -11,13 +11,26 @@ final class CommandFactoryTest extends TestCase
 {
 
     public function testGetCommandInstanceReturnsDDMSHelpCommandInstanceIfClassCorrespondingToSpecifiedCommandNameDoesNotExist(): void {
-        $commandFactory = new DDMSCommandFactory();
-        $this->assertTrue($commandFactory->getCommandInstance('Foo' . rand(10000,20000) . 'Bar' . rand(1000, 2000), new DDMSUserInterface()) instanceof DDMSHelpCommand);
+        $this->assertTrue(
+            $this->getCommandFactoryInstance()->getCommandInstance($this->getRandomName(), new DDMSUserInterface())
+            instanceof DDMSHelpCommand
+        );
     }
 
     public function testGetCommandInstanceReturnsDDMSHelpCommandInstanceIfSpecifiedCommandNameIs_help(): void {
-        $commandFactory = new DDMSCommandFactory();
-        $this->assertTrue($commandFactory->getCommandInstance('help', new DDMSUserInterface()) instanceof DDMSHelpCommand);
+        $this->assertTrue(
+            $this->getCommandFactoryInstance()->getCommandInstance('help', new DDMSUserInterface())
+            instanceof DDMSHelpCommand
+        );
+    }
+
+    private function getCommandFactoryInstance(): DDMSCommandFactory
+    {
+        return new DDMSCommandFactory();
+    }
+
+    private function getRandomName(): string {
+        return 'Foo' . rand(10000,20000) . 'Bar' . rand(1000, 2000);
     }
 
 }

--- a/tests/factory/CommandFactoryTest.php
+++ b/tests/factory/CommandFactoryTest.php
@@ -3,12 +3,21 @@
 namespace tests\command\AbstractCommand;
 
 use PHPUnit\Framework\TestCase;
-use ddms\classes\command\DDMSHelp as DDMSHelpCommand;
+use ddms\classes\command\Help as DDMSHelpCommand;
 use ddms\classes\ui\CommandLineUI as DDMSUserInterface;
-use ddms\interfaces\factory\CommandFactory as DDMSCommandFactory;;
+use ddms\classes\factory\CommandFactory as DDMSCommandFactory;;
 
 final class CommandFactoryTest extends TestCase
 {
 
-    public function testGetCommandInstanceReturnsDDMSHelpCommandInstanceIfSpecifiedCommandNameIs_help(): void { $this->assertTrue(true); }
+    public function testGetCommandInstanceReturnsDDMSHelpCommandInstanceIfClassCorrespondingToSpecifiedCommandNameDoesNotExist(): void {
+        $commandFactory = new DDMSCommandFactory();
+        $this->assertTrue($commandFactory->getCommandInstance('Foo' . rand(10000,20000) . 'Bar' . rand(1000, 2000), new DDMSUserInterface()) instanceof DDMSHelpCommand);
+    }
+
+    public function testGetCommandInstanceReturnsDDMSHelpCommandInstanceIfSpecifiedCommandNameIs_help(): void {
+        $commandFactory = new DDMSCommandFactory();
+        $this->assertTrue($commandFactory->getCommandInstance('help', new DDMSUserInterface()) instanceof DDMSHelpCommand);
+    }
+
 }

--- a/tests/factory/CommandFactoryTest.php
+++ b/tests/factory/CommandFactoryTest.php
@@ -11,8 +11,15 @@ final class CommandFactoryTest extends TestCase
 {
 
     public function testGetCommandInstanceReturnsHelpInstanceIfClassCorrespondingToSpecifiedCommandNameDoesNotExist(): void {
+        $commandName = $this->getRandomName();
+        $this->expectOutputString(
+            CommandFactory::class .
+            "Error:\e[0m\e[103m\e[30m `ddms --\e[0m\e[105m\e[30m" .
+            $commandName .
+            "\e[0m\e[103m\e[30m`, does not make sense. For help use `ddms --help`."
+        );
         $this->assertTrue(
-            $this->getCommandFactoryInstance()->getCommandInstance($this->getRandomName(), new CommandLineUI())
+            $this->getCommandFactoryInstance()->getCommandInstance($commandName, new CommandLineUI())
             instanceof Help
         );
     }

--- a/tests/factory/CommandFactoryTest.php
+++ b/tests/factory/CommandFactoryTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace tests\command\AbstractCommand;
+
+use PHPUnit\Framework\TestCase;
+use ddms\classes\command\DDMSHelp as DDMSHelpCommand;
+use ddms\classes\ui\CommandLineUI as DDMSUserInterface;
+use ddms\interfaces\factory\CommandFactory as DDMSCommandFactory;;
+
+final class CommandFactoryTest extends TestCase
+{
+
+    public function testGetCommandInstanceReturnsDDMSHelpCommandInstanceIfSpecifiedCommandNameIs_help(): void { $this->assertTrue(true); }
+}

--- a/tests/factory/CommandFactoryTest.php
+++ b/tests/factory/CommandFactoryTest.php
@@ -3,30 +3,30 @@
 namespace tests\command\AbstractCommand;
 
 use PHPUnit\Framework\TestCase;
-use ddms\classes\command\Help as DDMSHelpCommand;
-use ddms\classes\ui\CommandLineUI as DDMSUserInterface;
-use ddms\classes\factory\CommandFactory as DDMSCommandFactory;;
+use ddms\classes\command\Help;
+use ddms\classes\ui\CommandLineUI;
+use ddms\classes\factory\CommandFactory;
 
 final class CommandFactoryTest extends TestCase
 {
 
-    public function testGetCommandInstanceReturnsDDMSHelpCommandInstanceIfClassCorrespondingToSpecifiedCommandNameDoesNotExist(): void {
+    public function testGetCommandInstanceReturnsHelpInstanceIfClassCorrespondingToSpecifiedCommandNameDoesNotExist(): void {
         $this->assertTrue(
-            $this->getCommandFactoryInstance()->getCommandInstance($this->getRandomName(), new DDMSUserInterface())
-            instanceof DDMSHelpCommand
+            $this->getCommandFactoryInstance()->getCommandInstance($this->getRandomName(), new CommandLineUI())
+            instanceof Help
         );
     }
 
-    public function testGetCommandInstanceReturnsDDMSHelpCommandInstanceIfSpecifiedCommandNameIs_help(): void {
+    public function testGetCommandInstanceReturnsHelpInstanceIfSpecifiedCommandNameIs_help(): void {
         $this->assertTrue(
-            $this->getCommandFactoryInstance()->getCommandInstance('help', new DDMSUserInterface())
-            instanceof DDMSHelpCommand
+            $this->getCommandFactoryInstance()->getCommandInstance('help', new CommandLineUI())
+            instanceof Help
         );
     }
 
-    private function getCommandFactoryInstance(): DDMSCommandFactory
+    private function getCommandFactoryInstance(): CommandFactory
     {
-        return new DDMSCommandFactory();
+        return new CommandFactory();
     }
 
     private function getRandomName(): string {

--- a/tests/ui/AbstractUserInterfaceTest.php
+++ b/tests/ui/AbstractUserInterfaceTest.php
@@ -10,7 +10,7 @@ final class AbstractUserInterfaceTest extends TestCase
 {
 
     public function testShowMessageOutputsSpecifiedMessage(): void {
-        $message = 'Abstract User Interface';
+        $message = 'Abstract User Interface' . rand(1000, PHP_INT_MAX);;
         $ui = $this
             ->getMockBuilder(AbstractUserInterface::class)
             ->getMockForAbstractClass();

--- a/tests/ui/AbstractUserInterfaceTest.php
+++ b/tests/ui/AbstractUserInterfaceTest.php
@@ -3,15 +3,15 @@
 namespace tests\ui;
 
 use PHPUnit\Framework\TestCase;
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
-use ddms\abstractions\ui\AbstractUserInterface as AbstractDDMSUserInterface;
+use ddms\interfaces\ui\UserInterface;
+use ddms\abstractions\ui\AbstractUserInterface;
 
 final class AbstractUserInterfaceTest extends TestCase
 {
 
     public function testShowMessageOutputsSpecifiedMessage(): void {
         $ui = $this
-            ->getMockBuilder(AbstractDDMSUserInterface::class)
+            ->getMockBuilder(AbstractUserInterface::class)
             ->getMockForAbstractClass();
 
         $this->expectOutputString('Foo');

--- a/tests/ui/AbstractUserInterfaceTest.php
+++ b/tests/ui/AbstractUserInterfaceTest.php
@@ -9,49 +9,13 @@ use ddms\abstractions\ui\AbstractUserInterface as AbstractDDMSUserInterface;
 final class AbstractUserInterfaceTest extends TestCase
 {
 
-    public function testNotifyOutputsNoticeTypeNOTICEColonSpaceMessageIfNoNoticeTypeIsSpecified(): void {
+    public function testShowMessageOutputsSpecifiedMessage(): void {
         $ui = $this
             ->getMockBuilder(AbstractDDMSUserInterface::class)
             ->getMockForAbstractClass();
 
-        $this->expectOutputString(DDMSUserInterface::NOTICE . ': Foo');
-        $ui->notify('Foo');
-    }
-
-    public function testNotifyOutputsNoticeTypeNOTICEColonSpaceMessageIfTheNOTICENoticeTypeIsSpecified(): void {
-        $ui = $this
-            ->getMockBuilder(AbstractDDMSUserInterface::class)
-            ->getMockForAbstractClass();
-
-        $this->expectOutputString(DDMSUserInterface::NOTICE . ': Foo');
-        $ui->notify('Foo', DDMSUserInterface::NOTICE);
-    }
-
-    public function testNotifyOutputsNoticeTypeERRORColonSpaceMessageIfTheERRORNoticeTypeIsSpecified(): void {
-        $ui = $this
-            ->getMockBuilder(AbstractDDMSUserInterface::class)
-            ->getMockForAbstractClass();
-
-        $this->expectOutputString(DDMSUserInterface::ERROR . ': Foo');
-        $ui->notify('Foo', DDMSUserInterface::ERROR);
-    }
-
-    public function testNotifyOutputsNoticeTypeWARNINGColonSpaceMessageIfTheWARNINGNoticeTypeIsSpecified(): void {
-        $ui = $this
-            ->getMockBuilder(AbstractDDMSUserInterface::class)
-            ->getMockForAbstractClass();
-
-        $this->expectOutputString(DDMSUserInterface::WARNING . ': Foo');
-        $ui->notify('Foo', DDMSUserInterface::WARNING);
-    }
-
-    public function testNotifyOutputsNoticeTypeSUCCESSColonSpaceMessageIfTheSUCCESSNoticeTypeIsSpecified(): void {
-        $ui = $this
-            ->getMockBuilder(AbstractDDMSUserInterface::class)
-            ->getMockForAbstractClass();
-
-        $this->expectOutputString(DDMSUserInterface::SUCCESS . ': Foo');
-        $ui->notify('Foo', DDMSUserInterface::SUCCESS);
+        $this->expectOutputString('Foo');
+        $ui->showMessage('Foo');
     }
 
 }

--- a/tests/ui/AbstractUserInterfaceTest.php
+++ b/tests/ui/AbstractUserInterfaceTest.php
@@ -10,12 +10,13 @@ final class AbstractUserInterfaceTest extends TestCase
 {
 
     public function testShowMessageOutputsSpecifiedMessage(): void {
+        $message = 'Abstract User Interface';
         $ui = $this
             ->getMockBuilder(AbstractUserInterface::class)
             ->getMockForAbstractClass();
 
-        $this->expectOutputString('Foo');
-        $ui->showMessage('Foo');
+        $this->expectOutputString($message);
+        $ui->showMessage($message);
     }
 
 }

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -8,10 +8,20 @@ use ddms\classes\ui\CommandLineUI as DDMSCommandLineUI;
 
 final class CommandLineUITest extends TestCase
 {
+    private const BANNER = 'banner';
 
     private function getExpectedOuputForNoticeType(string $message, string $noticeType = ''): string
     {
-         return sprintf(
+        if($noticeType === self::BANNER){
+             return sprintf(
+                "%s%s%s%s",
+                PHP_EOL,
+                $message,
+                PHP_EOL,
+                PHP_EOL,
+            );
+        }
+        return sprintf(
             "%s%s%s%s%s%s%s%s%s%s%s",
             PHP_EOL,
             "\e[0m\e[105m\e[30m    ",
@@ -25,7 +35,6 @@ final class CommandLineUITest extends TestCase
             PHP_EOL,
             PHP_EOL,
         );
-
     }
 
     public function testNotifyOutputsMessageFormattedForNOTICETypeIfNoNoticeTypeIsSpecified(): void {
@@ -67,4 +76,17 @@ final class CommandLineUITest extends TestCase
         $this->expectOutputString($expectedOutput);
         $ui->notify($message, DDMSCommandLineUI::SUCCESS);
     }
+
+    public function testNotifyOutputsMessageFormattedForBANNERTypeIfBANNERNoticeTypeIsSpecified(): void {
+        $banner = "\e[0m\e[94m    _    _\e[0m
+        \e[0m\e[93m __| |__| |_ __  ___\e[0m
+        \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
+        \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
+        \e[0m\e[103m                    \e[0m";
+        $ui = new DDMSCommandLineUI();
+        $expectedOutput = $this->getExpectedOuputForNoticeType($banner, DDMSCommandLineUI::BANNER);
+        $this->expectOutputString($expectedOutput);
+        $ui->notify($banner, DDMSCommandLineUI::BANNER);
+    }
+
 }

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -3,23 +3,21 @@
 namespace tests\ui;
 
 use PHPUnit\Framework\TestCase;
-use ddms\interfaces\ui\UserInterface as DDMSUserInterface;
-use ddms\classes\ui\CommandLineUI as DDMSCommandLineUI;
+use ddms\interfaces\ui\UserInterface;
+use ddms\classes\ui\CommandLineUI;
 
 final class CommandLineUITest extends TestCase
 {
-    private const BANNER = 'banner';
 
-    private function getExpectedOuputForNoticeType(string $message, string $noticeType = ''): string
+    private function getExpectedOuput(string $message): string
     {
         return $message;
     }
 
     public function testNotifyOutputsMessageFormattedForNOTICETypeIfNoNoticeTypeIsSpecified(): void {
         $message = "Foo bar baz. Bazzer foo bar baz bazzer.";
-        $ui = new DDMSCommandLineUI();
-        $expectedOutput = $this->getExpectedOuputForNoticeType($message);
-        $this->expectOutputString($expectedOutput);
+        $ui = new CommandLineUI();
+        $this->expectOutputString($this->getExpectedOuput($message));
         $ui->showMessage($message);
     }
 

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -10,7 +10,7 @@ final class CommandLineUITest extends TestCase
 {
 
     public function testShowMessageOutputsSpecifiedMessage(): void {
-        $message = "Foo bar baz. Bazzer foo bar baz bazzer.";
+        $message = PHP_EOL . "\e[0m\e[102m\e[30m    Command Line UI    \e[0m" . PHP_EOL . PHP_EOL;
         $ui = new CommandLineUI();
         $this->expectOutputString($message);
         $ui->showMessage($message);

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -12,29 +12,7 @@ final class CommandLineUITest extends TestCase
 
     private function getExpectedOuputForNoticeType(string $message, string $noticeType = ''): string
     {
-        if($noticeType === self::BANNER){
-             return sprintf(
-                "%s%s%s%s",
-                PHP_EOL,
-                $message,
-                PHP_EOL,
-                PHP_EOL,
-            );
-        }
-        return sprintf(
-            "%s%s%s%s%s%s%s%s%s%s%s",
-            PHP_EOL,
-            "\e[0m\e[105m\e[30m    ",
-            "\e[0m\e[92m " . date('Y-m-d @ H:i:s') . "  \e[0m ",
-            "\e[0m\e[102m\e[30m" . (empty($noticeType) ? DDMSCommandLineUI::NOTICE : $noticeType) . "\e[0m\e[105m\e[30m    \e[0m",
-            PHP_EOL,
-            PHP_EOL,
-            "\e[0m\e[107m\e[30m",
-            $message,
-            "\e[0m",
-            PHP_EOL,
-            PHP_EOL,
-        );
+        return $message;
     }
 
     public function testNotifyOutputsMessageFormattedForNOTICETypeIfNoNoticeTypeIsSpecified(): void {
@@ -42,51 +20,7 @@ final class CommandLineUITest extends TestCase
         $ui = new DDMSCommandLineUI();
         $expectedOutput = $this->getExpectedOuputForNoticeType($message);
         $this->expectOutputString($expectedOutput);
-        $ui->notify($message);
-    }
-
-    public function testNotifyOutputsMessageFormattedForNOTICETypeIfNOTICENoticeTypeIsSpecified(): void {
-        $message = "Foo bar baz. Bazzer foo bar baz bazzer.";
-        $ui = new DDMSCommandLineUI();
-        $expectedOutput = $this->getExpectedOuputForNoticeType($message, DDMSCommandLineUI::NOTICE);
-        $this->expectOutputString($expectedOutput);
-        $ui->notify($message, DDMSCommandLineUI::NOTICE);
-    }
-
-    public function testNotifyOutputsMessageFormattedForERRORTypeIfERRORNoticeTypeIsSpecified(): void {
-        $message = "Foo bar baz. Bazzer foo bar baz bazzer.";
-        $ui = new DDMSCommandLineUI();
-        $expectedOutput = $this->getExpectedOuputForNoticeType($message, DDMSCommandLineUI::ERROR);
-        $this->expectOutputString($expectedOutput);
-        $ui->notify($message, DDMSCommandLineUI::ERROR);
-    }
-
-    public function testNotifyOutputsMessageFormattedForWARNINGTypeIfWARNINGNoticeTypeIsSpecified(): void {
-        $message = "Foo bar baz. Bazzer foo bar baz bazzer.";
-        $ui = new DDMSCommandLineUI();
-        $expectedOutput = $this->getExpectedOuputForNoticeType($message, DDMSCommandLineUI::WARNING);
-        $this->expectOutputString($expectedOutput);
-        $ui->notify($message, DDMSCommandLineUI::WARNING);
-    }
-
-    public function testNotifyOutputsMessageFormattedForSUCCESSTypeIfSUCCESSNoticeTypeIsSpecified(): void {
-        $message = "Foo bar baz. Bazzer foo bar baz bazzer.";
-        $ui = new DDMSCommandLineUI();
-        $expectedOutput = $this->getExpectedOuputForNoticeType($message, DDMSCommandLineUI::SUCCESS);
-        $this->expectOutputString($expectedOutput);
-        $ui->notify($message, DDMSCommandLineUI::SUCCESS);
-    }
-
-    public function testNotifyOutputsMessageFormattedForBANNERTypeIfBANNERNoticeTypeIsSpecified(): void {
-        $banner = "\e[0m\e[94m    _    _\e[0m
-        \e[0m\e[93m __| |__| |_ __  ___\e[0m
-        \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
-        \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-        \e[0m\e[103m                    \e[0m";
-        $ui = new DDMSCommandLineUI();
-        $expectedOutput = $this->getExpectedOuputForNoticeType($banner, DDMSCommandLineUI::BANNER);
-        $this->expectOutputString($expectedOutput);
-        $ui->notify($banner, DDMSCommandLineUI::BANNER);
+        $ui->showMessage($message);
     }
 
 }

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -9,15 +9,10 @@ use ddms\classes\ui\CommandLineUI;
 final class CommandLineUITest extends TestCase
 {
 
-    private function getExpectedOuput(string $message): string
-    {
-        return $message;
-    }
-
-    public function testNotifyOutputsMessageFormattedForNOTICETypeIfNoNoticeTypeIsSpecified(): void {
+    public function testShowMessageOutputsSpecifiedMessage(): void {
         $message = "Foo bar baz. Bazzer foo bar baz bazzer.";
         $ui = new CommandLineUI();
-        $this->expectOutputString($this->getExpectedOuput($message));
+        $this->expectOutputString($message);
         $ui->showMessage($message);
     }
 

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -10,7 +10,7 @@ final class CommandLineUITest extends TestCase
 {
 
     public function testShowMessageOutputsSpecifiedMessage(): void {
-        $message = PHP_EOL . "\e[0m\e[102m\e[30m    Command Line UI    \e[0m" . PHP_EOL . PHP_EOL;
+        $message = PHP_EOL . "\e[0m\e[102m\e[30m    Command Line UI " . rand(1000, PHP_INT_MAX) . "    \e[0m" . PHP_EOL . PHP_EOL;
         $ui = new CommandLineUI();
         $this->expectOutputString($message);
         $ui->showMessage($message);


### PR DESCRIPTION
ddms --help is working

Parsing `$argv` is working.

Options, flags, and flag arguments can be specified as follows:

`ddms OPTION1 OPTION2 --flag1 arg --flag2 arg1 arg2 --flag3 argFoo argBar --flag4 --flag5 etc`

The first flags found is always used to determine the command to run.

Code clean up.

Began development of ddms\classes\command\DDMS