### PR TITLE
Continued development of ddms. This commit is a candidate for a pre-release/

### DIFF
--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -8,10 +8,7 @@ use ddms\classes\command\DDMS;
 use ddms\classes\factory\CommandFactory;
 
 $ui = new UserInterface();
-$commandFactory = new CommandFactory();
-$help = new Help();
-$ddms = new DDMS($commandFactory);
-$arguments = $ddms->prepareArguments($argv);
+$ddms = new DDMS(new CommandFactory());
 
 $ui->showBanner();
 
@@ -19,9 +16,5 @@ try {
     $ddms->run($ui, $ddms->prepareArguments($argv));
 } catch(\RuntimeException $ddmsError) {
     $ui->showMessage($ddmsError->getMessage());
-}
-
-if(in_array('DEBUGOPTIONS' ,$arguments['options'])) {
-    $ui->showOptions($arguments);
 }
 

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -10,7 +10,7 @@ use ddms\classes\factory\CommandFactory;
 $ui = new UserInterface();
 $commandFactory = new CommandFactory();
 $help = new Help();
-$ddms = new DDMS();
+$ddms = new DDMS($commandFactory);
 $arguments = $ddms->prepareArguments($argv);
 
 $ui->showMessage(getBanner());

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -13,7 +13,7 @@ $help = new Help();
 $ddms = new DDMS($commandFactory);
 $arguments = $ddms->prepareArguments($argv);
 
-$ui->showMessage(getBanner());
+$ui->showBanner();
 
 try {
     $ddms->run($ui, $ddms->prepareArguments($argv));
@@ -60,18 +60,6 @@ function showFlags(UserInterface $ui, array $arguments): void
         }
         $ui->showMessage(PHP_EOL);
     }
-}
-
-function getBanner():string
-{
-    return
-    $banner = "
-  \e[0m\e[94m    _    _\e[0m
-  \e[0m\e[93m __| |__| |_ __  ___\e[0m
-  \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
-  \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-  \e[0m\e[105m\e[30m  v0.0.1  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
-
 }
 
 function getDevInvalidCommandMsg(\RuntimeException $ddmsError): string

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -22,44 +22,11 @@ try {
 }
 
 if(in_array('DEBUGOPTIONS' ,$arguments['options'])) {
-    showOptions($ui, $arguments);
+    $ui->showOptions($arguments);
 }
 
 if(in_array('DEBUGFLAGS' ,$arguments['options'])) {
-    showFlags($ui, $arguments);
-}
-
-/**
- * Dev Functions
- */
-
-/**
- * @param UserInterface $ui
- * @param array<mixed> $arguments
- */
-function showOptions(UserInterface $ui, array $arguments): void
-{
-    $ui->showMessage(PHP_EOL . '  Options:' . PHP_EOL);
-    foreach($arguments['options'] as $key => $option) {
-        $ui->showMessage("\e[0m  \e[101m\e[30m $key \e[0m\e[105m\e[30m : \e[0m\e[104m\e[30m $option \e[0m" . PHP_EOL);
-    }
-    $ui->showMessage(PHP_EOL);
-}
-
-/**
- * @param UserInterface $ui
- * @param array<mixed> $arguments
- */
-function showFlags(UserInterface $ui, array $arguments): void
-{
-    $ui->showMessage('  Flags:' . PHP_EOL);
-    foreach($arguments['flags'] as $key => $flags) {
-        $ui->showMessage("\e[0m  \e[101m\e[30m --$key \e[0m" . " : ");
-        foreach($flags as $key => $flagArgument) {
-            $ui->showMessage("\e[0m\e[104m\e[30m $flagArgument \e[0m" . "  ");
-        }
-        $ui->showMessage(PHP_EOL);
-    }
+    $ui->showFlags($arguments);
 }
 
 function getDevInvalidCommandMsg(\RuntimeException $ddmsError): string

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -25,8 +25,3 @@ if(in_array('DEBUGOPTIONS' ,$arguments['options'])) {
     $ui->showOptions($arguments);
 }
 
-if(in_array('DEBUGFLAGS' ,$arguments['options'])) {
-    $ui->showFlags($arguments);
-}
-
-

--- a/bin/ddms.php
+++ b/bin/ddms.php
@@ -18,7 +18,7 @@ $ui->showBanner();
 try {
     $ddms->run($ui, $ddms->prepareArguments($argv));
 } catch(\RuntimeException $ddmsError) {
-    $ui->showMessage(getDevInvalidCommandMsg($ddmsError));
+    $ui->showMessage($ddmsError->getMessage());
 }
 
 if(in_array('DEBUGOPTIONS' ,$arguments['options'])) {
@@ -29,19 +29,4 @@ if(in_array('DEBUGFLAGS' ,$arguments['options'])) {
     $ui->showFlags($arguments);
 }
 
-function getDevInvalidCommandMsg(\RuntimeException $ddmsError): string
-{
-    return PHP_EOL .
-            "\e[0m  \e[103m\e[30m" .
-            str_replace(
-                [
-                    'Error',
-                    'ddms --help'
-                ],
-                [
-                    "\e[0m\e[102m\e[30mError\e[0m\e[103m\e[30m",
-                    "\e[0m\e[104m\e[30mddms --help\e[0m\e[103m\e[30m"
-                ],
-                $ddmsError->getMessage()
-            ) . "\e[0m" . PHP_EOL;
-}
+

--- a/ddms/abstractions/ui/AbstractUserInterface.php
+++ b/ddms/abstractions/ui/AbstractUserInterface.php
@@ -11,4 +11,15 @@ abstract class AbstractUserInterface implements UserInterface
     {
         echo $message;
     }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    abstract public function showOptions(array $arguments): void;
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    abstract public function showFlags(array $arguments): void;
+
 }

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -17,11 +17,15 @@ class DDMS extends AbstractDDMS implements Command
     {
         ['flags' => $flags] = $preparedArguments;
         if(!empty($flags)) {
-            $flags = array_keys($flags);
-            $command = $this->convertFlagToCommandName(array_shift($flags));
+            $flagNames = array_keys($flags);
+            $command = $this->convertFlagToCommandName(array_shift($flagNames));
             $expectedCommandNamespace = "\\ddms\\classes\\command\\$command";
             if($this->commandExists($expectedCommandNamespace)) {
-                return $this->commandFactory->getCommandInstance($command, $userInterface)->run($userInterface, $preparedArguments);
+                $result = $this->commandFactory->getCommandInstance($command, $userInterface)->run($userInterface, $preparedArguments);
+                if(in_array('debug', $flagNames, true) && in_array('flags', $flags['debug'], true)) {
+                    $userInterface->showFlags($preparedArguments);
+                }
+                return $result;
             }
             $this->commandFactory->getCommandInstance('Help', $userInterface)->run($userInterface, $this->prepareArguments(['--help']));
             return throw new RuntimeException($this->getInvalidCommandMsg());

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -6,9 +6,12 @@ use ddms\interfaces\command\Command;
 use ddms\abstractions\command\AbstractDDMS;
 use ddms\interfaces\ui\UserInterface;
 use \RuntimeException;
+use ddms\classes\factory\CommandFactory;
 
 class DDMS extends AbstractDDMS implements Command
 {
+
+    public function __construct(private CommandFactory $commandFactory) {}
 
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
@@ -18,9 +21,9 @@ class DDMS extends AbstractDDMS implements Command
             $command = $this->convertFlagToCommandName(array_shift($flags));
             $expectedCommandNamespace = "\\ddms\\classes\\command\\$command";
             if($this->commandExists($expectedCommandNamespace)) {
-                $commandInstance = new $expectedCommandNamespace();
-                return $commandInstance->run($userInterface, $preparedArguments);
+                return $this->commandFactory->getCommandInstance($command, $userInterface)->run($userInterface, $preparedArguments);
             }
+            $this->commandFactory->getCommandInstance('Help', $userInterface)->run($userInterface, $this->prepareArguments(['--help']));
             return throw new RuntimeException("Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information.");
         }
         return false;

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -24,7 +24,7 @@ class DDMS extends AbstractDDMS implements Command
                 return $this->commandFactory->getCommandInstance($command, $userInterface)->run($userInterface, $preparedArguments);
             }
             $this->commandFactory->getCommandInstance('Help', $userInterface)->run($userInterface, $this->prepareArguments(['--help']));
-            return throw new RuntimeException("Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information.");
+            return throw new RuntimeException($this->getInvalidCommandMsg());
         }
         return false;
     }
@@ -45,4 +45,20 @@ class DDMS extends AbstractDDMS implements Command
         return str_replace(' ', '', ucwords(str_replace('-', ' ', $string)));
     }
 
+    private function getInvalidCommandMsg(): string
+    {
+        return PHP_EOL .
+                "\e[0m  \e[103m\e[30m" .
+                str_replace(
+                    [
+                        'Error',
+                        'ddms --help'
+                    ],
+                    [
+                        "\e[0m\e[102m\e[30mError\e[0m\e[103m\e[30m",
+                        "\e[0m\e[104m\e[30mddms --help\e[0m\e[103m\e[30m"
+                    ],
+                    "Error: The first flag specified MUST correspond to an existing ddms command. Please use ddms --help for more information."
+                ) . "\e[0m" . PHP_EOL;
+    }
 }

--- a/ddms/classes/command/DDMS.php
+++ b/ddms/classes/command/DDMS.php
@@ -22,6 +22,9 @@ class DDMS extends AbstractDDMS implements Command
             $expectedCommandNamespace = "\\ddms\\classes\\command\\$command";
             if($this->commandExists($expectedCommandNamespace)) {
                 $result = $this->commandFactory->getCommandInstance($command, $userInterface)->run($userInterface, $preparedArguments);
+                if(in_array('debug', $flagNames, true) && in_array('options', $flags['debug'], true)) {
+                    $userInterface->showOptions($preparedArguments);
+                }
                 if(in_array('debug', $flagNames, true) && in_array('flags', $flags['debug'], true)) {
                     $userInterface->showFlags($preparedArguments);
                 }

--- a/ddms/classes/ui/CommandLineUI.php
+++ b/ddms/classes/ui/CommandLineUI.php
@@ -28,4 +28,31 @@ class CommandLineUI implements UserInterface
       \e[0m\e[105m\e[30m  v0.0.3  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
     }
 
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    public function showOptions(array $arguments): void
+    {
+        $this->showMessage(PHP_EOL . '  Options:' . PHP_EOL);
+        foreach($arguments['options'] as $key => $option) {
+            $this->showMessage("\e[0m  \e[101m\e[30m $key \e[0m\e[105m\e[30m : \e[0m\e[104m\e[30m $option \e[0m" . PHP_EOL);
+        }
+        $this->showMessage(PHP_EOL);
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    public function showFlags(array $arguments): void
+    {
+        $this->showMessage('  Flags:' . PHP_EOL);
+        foreach($arguments['flags'] as $key => $flags) {
+            $this->showMessage("\e[0m  \e[101m\e[30m --$key \e[0m" . " : ");
+            foreach($flags as $key => $flagArgument) {
+                $this->showMessage("\e[0m\e[104m\e[30m $flagArgument \e[0m" . "  ");
+            }
+            $this->showMessage(PHP_EOL);
+        }
+    }
+
 }

--- a/ddms/classes/ui/CommandLineUI.php
+++ b/ddms/classes/ui/CommandLineUI.php
@@ -21,11 +21,11 @@ class CommandLineUI implements UserInterface
     {
         return
         "
-      \e[0m\e[94m    _    _\e[0m
-      \e[0m\e[93m __| |__| |_ __  ___\e[0m
-      \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
-      \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-      \e[0m\e[105m\e[30m  v0.0.3  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
+  \e[0m\e[94m    _    _\e[0m
+  \e[0m\e[93m __| |__| |_ __  ___\e[0m
+  \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
+  \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
+  \e[0m\e[105m\e[30m  v0.0.3  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
     }
 
     /**

--- a/ddms/classes/ui/CommandLineUI.php
+++ b/ddms/classes/ui/CommandLineUI.php
@@ -12,4 +12,20 @@ class CommandLineUI implements UserInterface
         echo $message;
     }
 
+    public function showBanner(): void
+    {
+        $this->showMessage($this->getBanner());
+    }
+
+    private function getBanner():string
+    {
+        return
+        "
+      \e[0m\e[94m    _    _\e[0m
+      \e[0m\e[93m __| |__| |_ __  ___\e[0m
+      \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
+      \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
+      \e[0m\e[105m\e[30m  v0.0.3  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
+    }
+
 }

--- a/ddms/interfaces/ui/UserInterface.php
+++ b/ddms/interfaces/ui/UserInterface.php
@@ -6,4 +6,14 @@ interface UserInterface {
 
     public function showMessage(string $message): void;
 
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    public function showOptions(array $arguments): void;
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    public function showFlags(array $arguments): void;
+
 }

--- a/tests/ListOfImplementedTests.txt
+++ b/tests/ListOfImplementedTests.txt
@@ -1,0 +1,22 @@
+./tests/factory/CommandFactoryTest.php     testGetCommandInstanceReturnsHelpInstanceIfClassCorrespondingToSpecifiedCommandNameDoesNotExist(): void {
+./tests/factory/CommandFactoryTest.php     testGetCommandInstanceReturnsInstanceOfSpecifiedCommandIfSpecifiedCommandExists(): void {
+./tests/ui/AbstractUserInterfaceTest.php     testShowMessageOutputsSpecifiedMessage(): void {
+./tests/ui/CommandLineUITest.php     testShowMessageOutputsSpecifiedMessage(): void {
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayWhoseNonRecursiveCountIsTwo(): void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayWhoseTopLevelIndexesAre_flags__And__options(): void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayAtIndex_flags(): void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayWhoseKeysAreStringsAtIndex_flags():void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayWhoseValuesAreArraysAtIndex_flags():void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayOfArraysWhoseKeysAreIntsAtIndex_flags():void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayOfArraysWhoseValuesAreStringsAtIndex_flags():void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayAtIndex_options(): void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayWhoseKeysAreIntsAtIndex_options():void
+./tests/command/AbstractCommandTest.php     testPrepareArgumentsReturnsAnArrayThatIsAssignedAnArrayWhoseValuesAreStringsAtIndex_options():void
+./tests/command/HelpTest.php     testRunOutputsHelpFile_Help_IfNoFlagsOrOptionsAreSpecified(): void
+./tests/command/HelpTest.php     testRunOutputsEmptyStringIfFlagsAreSpecifiedAndHelpFlagIsNotPresent(): void
+./tests/command/HelpTest.php     testRunOutputsHelpFile_Help_IfHelpFlagIsSpecifiedAndHasNoArguments(): void
+./tests/command/DDMSTest.php     testRunCommandReturnValueAndOutputMatchesReturnValueAndOutputOfIndpendantCallToSpecifiedCommandsRunMethod(): void
+./tests/command/DDMSTest.php     testRunCommandReturnValueAndOutputMatchesReturnValueAndOutputOfIndpendantCallToRunMethodOfCommandThatCorrespondsToFirstFlag(): void
+./tests/command/DDMSTest.php     testRunOutputs_help_HelpFileContentsAndThrowsARuntimeExceptionIfFlagsAreSpecifiedAndFirstFlagDoesNotCorrespondToAnExistingCommand(): void
+./tests/command/AbstractDDMSTest.php     testRunCommandReturnsValueMatchingValueReturnedOnIndependantCallToSpecifiedCommandsRunMethod(): void
+./tests/command/AbstractDDMSTest.php     testRunCommandOutputMatchesOutputOfIndpendantCallToSpecifiedCommandsRunMethod(): void

--- a/tests/command/DDMSTest.php
+++ b/tests/command/DDMSTest.php
@@ -57,12 +57,33 @@ final class DDMSTest extends TestCase
         $ddms->run($this->getMockUserInterface(), $ddms->prepareArguments($argv));
     }
 
+    public function testRunOutputIncludesOutputOfUserInterface_showOptions_MethodIf_debug_FlagsIsSpecifiedWithFlagArgument_options(): void
+    {
+        $helpCommand = new Help();
+        $ddms = $this->getMockDDMS();
+        $argv = ['--help', '--debug', 'options'];
+        $this->expectOutputString(
+            PHP_EOL . file_get_contents($this->determineHelpFilePath('help')) . PHP_EOL .
+            $this->expectedShowOptionsOutput($ddms->prepareArguments($argv))
+        );
+        $ddms->run($this->getMockUserInterface(), $ddms->prepareArguments($argv));
+    }
+
     public function testRunOutputs_help_HelpFileContentsAndThrowsARuntimeExceptionIfFlagsAreSpecifiedAndFirstFlagDoesNotCorrespondToAnExistingCommand(): void
     {
         $ddms = $this->getMockDDMS();
         $this->expectOutputString(PHP_EOL . file_get_contents($this->determineHelpFilePath('help')) . PHP_EOL);
         $this->expectException(RuntimeException::class);
         $ddms->run($this->getMockUserInterface(), $ddms->prepareArguments(['--command-does-not-exist', 'flagArg1', 'flagArg2']));
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    public function expectedShowOptionsOutput(array $arguments): string
+    {
+        $mockUI = new MockDDMSUserInterface();
+        return $mockUI->expectedShowOptionsOutput($arguments);
     }
 
     /**
@@ -137,6 +158,20 @@ final class MockDDMSUserInterface extends AbstractUserInterface implements UserI
         }
         $this->showMessage(PHP_EOL);
     }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    public function expectedShowOptionsOutput(array $arguments): string
+    {
+        $output = (PHP_EOL . '  Options:' . PHP_EOL);
+        foreach($arguments['options'] as $key => $option) {
+            $output .= ("    $key : $option" . PHP_EOL);
+        }
+        $output .= (PHP_EOL);
+        return $output;
+    }
+
 
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments

--- a/tests/command/DDMSTest.php
+++ b/tests/command/DDMSTest.php
@@ -3,6 +3,7 @@
 namespace tests\command;
 
 use PHPUnit\Framework\TestCase;
+use ddms\classes\factory\CommandFactory;
 use ddms\classes\command\Help;
 use ddms\classes\command\DDMS;
 use ddms\abstractions\command\AbstractCommand;
@@ -48,9 +49,10 @@ final class DDMSTest extends TestCase
         );
     }
 
-    public function testRunThrowsARuntimeExceptionIfFlagsAreSpecifiedAndFirstFlagDoesNotCorrespondToAnExistingCommand(): void
+    public function testRunOutputs_help_HelpFileContentsAndThrowsARuntimeExceptionIfFlagsAreSpecifiedAndFirstFlagDoesNotCorrespondToAnExistingCommand(): void
     {
         $ddms = $this->getMockDDMS();
+        $this->expectOutputString(PHP_EOL . file_get_contents($this->determineHelpFilePath('help')) . PHP_EOL);
         $this->expectException(RuntimeException::class);
         $ddms->run($this->getMockUserInterface(), $ddms->prepareArguments(['--command-does-not-exist', 'flagArg1', 'flagArg2']));
     }
@@ -81,7 +83,7 @@ final class DDMSTest extends TestCase
 
     private function getMockDDMS(): DDMS
     {
-        return new DDMS();
+        return new DDMS(new CommandFactory());
     }
 
 }

--- a/tests/command/DDMSTest.php
+++ b/tests/command/DDMSTest.php
@@ -33,7 +33,7 @@ final class DDMSTest extends TestCase
         $helpCommand = new Help();
         $ddms = $this->getMockDDMS();
         $ui = $this->getMockUserInterface();
-        $argv = ['--help'];
+        $argv = ['--help', '--flag1', '--flag2'];
         $this->expectOutputString(
             PHP_EOL . file_get_contents($this->determineHelpFilePath('help')) . PHP_EOL .
             PHP_EOL . file_get_contents($this->determineHelpFilePath('help')) . PHP_EOL

--- a/tests/command/DDMSTest.php
+++ b/tests/command/DDMSTest.php
@@ -28,12 +28,7 @@ final class DDMSTest extends TestCase
         $this->getMockDDMS()->runCommand($this->getMockUserInterface(), $this->getMockDDMSCommand(), $this->mockArgvArrayWithFlagsAndOptions());
     }
 
-    private function determineHelpFilePath(string $helpFlagName): string
-    {
-        return str_replace('tests/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
-    }
-
-    public function testRunCommandReturnValueAndOutputMatchesReturnValueAndOutputOfIndpendantCallToRunMethodOfCommandThatCorrespondsToFirstFlag(): void
+    public function testRunReturnValueAndOutputMatchesReturnValueAndOutputOfIndpendantCallToRunMethodOfExistingCommandThatCorrespondsToFirstFlag(): void
     {
         $helpCommand = new Help();
         $ddms = $this->getMockDDMS();
@@ -57,7 +52,10 @@ final class DDMSTest extends TestCase
         $ddms->run($this->getMockUserInterface(), $ddms->prepareArguments(['--command-does-not-exist', 'flagArg1', 'flagArg2']));
     }
 
-   # NOTE: need testDDMSPrepareArgsReturnsValueMatchingIndependantCallToRelevantCommandsPrepareArgsIfFirstFlagSpecifiedCorrespondsToAnExistingCommand(): void
+    private function determineHelpFilePath(string $helpFlagName): string
+    {
+        return str_replace('tests/command','helpFiles', __DIR__) . DIRECTORY_SEPARATOR . $helpFlagName . '.txt';
+    }
 
     private function getMockDDMSCommand(): AbstractCommand
     {

--- a/tests/factory/CommandFactoryTest.php
+++ b/tests/factory/CommandFactoryTest.php
@@ -18,11 +18,19 @@ final class CommandFactoryTest extends TestCase
         );
     }
 
-    public function testGetCommandInstanceReturnsHelpInstanceIfSpecifiedCommandNameIs_help(): void {
+    public function testGetCommandInstanceReturnsInstanceOfSpecifiedCommandIfSpecifiedCommandExists(): void {
+        $commandName = $this->getRandomExistingCommandName();
+        $expectedCommandNamespace = 'ddms\\classes\\command\\' . $commandName;
         $this->assertTrue(
-            $this->getCommandFactoryInstance()->getCommandInstance('help', new CommandLineUI())
-            instanceof Help
+            $this->getCommandFactoryInstance()->getCommandInstance($commandName, new CommandLineUI())
+            instanceof $expectedCommandNamespace
         );
+    }
+
+    private function getRandomExistingCommandName(): string
+    {
+        $existinCommandNames = ['help'];
+        return $existinCommandNames[array_rand($existinCommandNames)];
     }
 
     private function getCommandFactoryInstance(): CommandFactory

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -23,7 +23,52 @@ final class CommandLineUITest extends TestCase
         $ui->showBanner();
     }
 
-    public function expectedBanner():string
+    public function testShowOptionsOutputsExpectedOutput(): void
+    {
+        $arguments = ['flags' => [], 'options' => ['foo', 'bar', 'baz']];
+        $this->expectOutputString($this->expectedShowOptionsOutput($arguments));
+        $ui = new CommandLineUI();
+        $ui->showOptions($arguments);
+    }
+
+    public function testShowFlagsOutputsExpectedOutput(): void
+    {
+        $arguments = ['flags' => [], 'options' => ['foo', 'bar', 'baz']];
+        $this->expectOutputString($this->expectedShowFlagsOutput($arguments));
+        $ui = new CommandLineUI();
+        $ui->showFlags($arguments);
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    private function expectedShowOptionsOutput(array $arguments): string
+    {
+        $output = (PHP_EOL . '  Options:' . PHP_EOL);
+        foreach($arguments['options'] as $key => $option) {
+            $output .= ("\e[0m  \e[101m\e[30m $key \e[0m\e[105m\e[30m : \e[0m\e[104m\e[30m $option \e[0m" . PHP_EOL);
+        }
+        $output .= (PHP_EOL);
+        return $output;
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $arguments
+     */
+    public function expectedShowFlagsOutput(array $arguments): string
+    {
+        $output = ('  Flags:' . PHP_EOL);
+        foreach($arguments['flags'] as $key => $flags) {
+            $output .= ("\e[0m  \e[101m\e[30m --$key \e[0m" . " : ");
+            foreach($flags as $key => $flagArgument) {
+                $output .= ("\e[0m\e[104m\e[30m $flagArgument \e[0m" . "  ");
+            }
+            $output .= (PHP_EOL);
+        }
+        return $output;
+    }
+
+    private function expectedBanner():string
     {
         return
         "

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -72,11 +72,11 @@ final class CommandLineUITest extends TestCase
     {
         return
         "
-      \e[0m\e[94m    _    _\e[0m
-      \e[0m\e[93m __| |__| |_ __  ___\e[0m
-      \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
-      \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-      \e[0m\e[105m\e[30m  v0.0.3  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
+  \e[0m\e[94m    _    _\e[0m
+  \e[0m\e[93m __| |__| |_ __  ___\e[0m
+  \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
+  \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
+  \e[0m\e[105m\e[30m  v0.0.3  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
     }
 
 }

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -16,4 +16,22 @@ final class CommandLineUITest extends TestCase
         $ui->showMessage($message);
     }
 
+    public function testShowBannerOutputsDDMSBanner(): void
+    {
+        $this->expectOutputString($this->expectedBanner());
+        $ui = new CommandLineUI();
+        $ui->showBanner();
+    }
+
+    public function expectedBanner():string
+    {
+        return
+        "
+      \e[0m\e[94m    _    _\e[0m
+      \e[0m\e[93m __| |__| |_ __  ___\e[0m
+      \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
+      \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
+      \e[0m\e[105m\e[30m  v0.0.3  \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m";
+    }
+
 }


### PR DESCRIPTION
 `ddms\classes\command\DDMS`: Refactored `ddms\classes\command\DDMS` to use a `CommandFactory` instance to build the `Command` instances it runs

`tests\factory\CommandFactoryTest`: Refactored `testGetCommandInstanceReturnsHelpInstanceIfSpecifiedCommandNameIs_help()` to instead `testGetCommandInstanceReturnsInstanceOfSpecifiedCommandIfSpecifiedCommandExists()`. 

`tests\command\DDMSTest`: Code clean up

`ddms\classes\ui\CommandLineUI`: Added new method, `showBanner()`. Implemented `testShowBannerOutputsDDMSBanner()`. 

`ddms\classes\ui\CommandLineUI`: Added new methods `showFlags()` and `showOptions()`. Implemented `testShowOptionsOutputsExpectedOutput()` and `testShowFlagsOutputsExpectedOutput()`. 

`ddms\classes\command\DDMS | bin/ddms.php`: Finished migrating appropriate functions declared in `bin/ddms.php` to `ddms/classes/command/DDMS.php`.

`ddms\interfaces\ui\UserInterface | ddms\abstractions\ui\AbstractUserInterface`:

Added showFlags() and `showOptions()` to `ddms\interfaces\ui\UserInterface`.

`ddms\classes\command\DDMS`: Implemented `testRunOutputIncludesOutputOfUserInterface_showFlags_MethodIf_debug_FlagsIsSpecifiedWithFlagArgument_flags()`
in `tests\command\DDMSTest`.

`bin/ddms.php`: Removed call to `$ui->showFlags()`, DDMS now handles the --debug flags which replace the debug options.

`ddms\classes\command\DDMS`: Implemented `testRunOutputIncludesOutputOfUserInterface_showFlags_MethodIf_debug_FlagsIsSpecifiedWithFlagArgument_options`. 

`ddms\classes\ui\CommandLineUI`: Refactored banner output.

`bin/ddms.php`: Code clean up 