### PR TITLE
Code clean up | Refactoring | New Tests

### DIFF
--- a/bin/ddms
+++ b/bin/ddms
@@ -40,4 +40,5 @@ loadLibrary() {
 
 [[ -z "$(command -v php)" ]] && logErrorMsgAndExit1 "php is not available!"
 
-"$(command -v php)" "$(determineDDMSDirectoryPath)/ddms.php" $@ --ddms-internal-flag-pwd "$(pwd)"
+"$(command -v php)" "$(determineDDMSDirectoryPath)/ddms.php" $@
+

--- a/composer.lock
+++ b/composer.lock
@@ -461,16 +461,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -522,9 +522,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -906,16 +906,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.2",
+            "version": "9.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4"
+                "reference": "27241ac75fc37ecf862b6e002bf713b6566cbe41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f661659747f2f87f9e72095bb207bceb0f151cb4",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/27241ac75fc37ecf862b6e002bf713b6566cbe41",
+                "reference": "27241ac75fc37ecf862b6e002bf713b6566cbe41",
                 "shasum": ""
             },
             "require": {
@@ -993,7 +993,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.3"
             },
             "funding": [
                 {
@@ -1005,7 +1005,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-02T14:45:58+00:00"
+            "time": "2021-03-17T07:30:34+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/ddms/abstractions/command/AbstractCommand.php
+++ b/ddms/abstractions/command/AbstractCommand.php
@@ -23,9 +23,9 @@ abstract class AbstractCommand implements Command
     private function validateArguments(array $flagsAndOptions): array
     {
         ['flags' => $flags] = $flagsAndOptions;
-        if(!in_array('ddms-internal-flag-pwd', array_keys($flags)) || !isset($flags['ddms-internal-flag-pwd'][0]) || !file_exists($flags['ddms-internal-flag-pwd'][0])) {
+        if(!in_array('ddms-apps-directory-path', array_keys($flags)) || !isset($flags['ddms-apps-directory-path'][0]) || !file_exists($flags['ddms-apps-directory-path'][0])) {
             $ddmsTmpDirPath = str_replace('ddms' . DIRECTORY_SEPARATOR . 'abstractions' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__);
-            $flagsAndOptions['flags']['ddms-internal-flag-pwd'] = [$ddmsTmpDirPath];
+            $flagsAndOptions['flags']['ddms-apps-directory-path'] = [$ddmsTmpDirPath];
         }
         return $flagsAndOptions;
     }

--- a/ddms/abstractions/command/AbstractCommand.php
+++ b/ddms/abstractions/command/AbstractCommand.php
@@ -23,13 +23,25 @@ abstract class AbstractCommand implements Command
     private function validateArguments(array $flagsAndOptions): array
     {
         ['flags' => $flags] = $flagsAndOptions;
-        if(!in_array('ddms-apps-directory-path', array_keys($flags)) || !isset($flags['ddms-apps-directory-path'][0]) || !file_exists($flags['ddms-apps-directory-path'][0])) {
-            $ddmsTmpDirPath = str_replace('ddms' . DIRECTORY_SEPARATOR . 'abstractions' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__);
+        if(!in_array('ddms-apps-directory-path', array_keys($flags)) || !isset($flags['ddms-apps-directory-path'][0]) || !file_exists($flags['ddms-apps-directory-path'][0]) || !is_dir($flags['ddms-apps-directory-path'][0])) {
+            $ddmsTmpDirPath = $this->determineDefaultAppsDirectoryPath($flags);
             $flagsAndOptions['flags']['ddms-apps-directory-path'] = [$ddmsTmpDirPath];
         }
         return $flagsAndOptions;
     }
 
+    /**
+     * @param array<string, array<int, string>> $flags
+     */
+    private function determineDefaultAppsDirectoryPath(array $flags): string
+    {
+        $expectedDarlingDMSAppsDirectory = strval(realpath(str_replace('vendor' . DIRECTORY_SEPARATOR . 'darling' . DIRECTORY_SEPARATOR . 'ddms' . DIRECTORY_SEPARATOR . 'ddms' . DIRECTORY_SEPARATOR . 'abstractions' . DIRECTORY_SEPARATOR .  'command', 'Apps', __DIR__)));
+        $ddmsTmpDirectoryPath = strval(realpath(str_replace('ddms' . DIRECTORY_SEPARATOR . 'abstractions' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__)));
+        if(!in_array('ddms-apps-directory-path', array_keys($flags)) && file_exists($expectedDarlingDMSAppsDirectory) && is_dir($expectedDarlingDMSAppsDirectory)) {
+            return $expectedDarlingDMSAppsDirectory;
+        }
+        return $ddmsTmpDirectoryPath;
+    }
 
     /**
      * @param array<int, string> $argv

--- a/ddms/classes/command/NewApp.php
+++ b/ddms/classes/command/NewApp.php
@@ -16,7 +16,7 @@ class NewApp extends AbstractCommand implements Command
         if(!in_array('name', array_keys($flags))) {
             throw new RuntimeException('  You must specify a name for the new App');
         }
-        $appDirectoryPath = $flags['ddms-internal-flag-pwd'][0] . DIRECTORY_SEPARATOR . $flags['name'][0];
+        $appDirectoryPath = $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['name'][0];
         if(is_dir($appDirectoryPath)) {
             throw new RuntimeException('An App named ' .  $flags['name'][0] . ' already exists. Please specify a unique name.');
         }

--- a/helpFiles/help.txt
+++ b/helpFiles/help.txt
@@ -11,6 +11,14 @@
   `ddms --help [FLAG]`
   `ddms --start-server [--port] [--root-dir] [--php-ini] [--open-in-browser]`
   `ddms --view-active-servers`
+  `ddms --new-app --name [--domain]`
+
+  For more information about a specific command use `ddms --help [FLAG]`. For
+  example, to get help information about the --new-app command use either of
+  the following calls to --help:
+
+    `ddms --help --new-app`
+    `ddms --help new-app`
 
   For more information go to:
   https://github.com/sevidmusic/ddms

--- a/helpFiles/start-server.txt
+++ b/helpFiles/start-server.txt
@@ -13,7 +13,7 @@
   --port              A port between 8000 and 8999. This flag is optional, defaults
                       to 8080.
 
-  --root-directory    The directory to use as the server's root directory. This flag
+  --root-dir          The directory to use as the server's root directory. This flag
                       is optional, defaults to current directory.
 
   --ini-file          Path to a php.ini file to use to configure php for the server.

--- a/tests/command/AbstractCommandTest.php
+++ b/tests/command/AbstractCommandTest.php
@@ -8,34 +8,51 @@ use ddms\abstractions\command\AbstractCommand;
 final class AbstractCommandTest extends TestCase
 {
 
-    public function testPrepareArgumentsReturnsArrayWith_ddms_internal_flag_pwd_FlagPresent(): void
+    public function testPrepareArgumentsReturnsArrayWith_ddms_apps_directory_path_FlagPresent(): void
     {
-        $this->assertTrue(isset($this->getMockCommand()->prepareArguments($this->getMockArray())['flags']['ddms-internal-flag-pwd']));
+        $this->assertTrue(isset($this->getMockCommand()->prepareArguments($this->getMockArray())['flags']['ddms-apps-directory-path']));
     }
 
-    public function testPrepareArgumentsReturnsArrayWhose_ddms_internal_flag_pwd_FlagIsAssignedAtLeastOneArgument(): void
+    public function testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagIsAssignedAtLeastOneArgument(): void
     {
-        $this->assertTrue(isset($this->getMockCommand()->prepareArguments($this->getMockArray())['flags']['ddms-internal-flag-pwd'][0]));
+        $this->assertTrue(isset($this->getMockCommand()->prepareArguments($this->getMockArray())['flags']['ddms-apps-directory-path'][0]));
     }
 
-    public function testPrepareArgumentsReturnsArrayWhose_ddms_internal_flag_pwd_FlagsFirstAssignedArgumentIsAPathToAnExistingDirectory(): void
+    public function testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstAssignedArgumentIsAPathToAnExistingDirectoryEvenIfFirstSpecifiedArgumentIsNotAPathToAnExistingDirectory(): void
     {
-        $this->assertTrue(file_exists($this->getMockCommand()->prepareArguments(['--ddms-internal-flag-pwd', 'FooBar' . strval(rand(1000,999))])['flags']['ddms-internal-flag-pwd'][0]));
+        $this->assertTrue(file_exists($this->getMockCommand()->prepareArguments(['--ddms-apps-directory-path', 'FooBar' . strval(rand(1000,999))])['flags']['ddms-apps-directory-path'][0]));
+        $this->assertTrue(is_dir($this->getMockCommand()->prepareArguments(['--ddms-apps-directory-path', 'FooBar' . strval(rand(1000,999))])['flags']['ddms-apps-directory-path'][0]));
     }
 
-    public function testPrepareArgumentsReturnsArrayWhose_ddms_internal_flag_pwd_FlagsFirstAssignedArgumentMatchesSpecifiedArgumentIfFirstArgumentIsAPathToAnExistingDirectory(): void
+    public function testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstAssignedArgumentMatchesSpecifiedArgumentIfSpecifiedArgumentIsAPathToAnExistingDirectory(): void
     {
         $this->assertEquals(
             __DIR__,
-            $this->getMockCommand()->prepareArguments(['--ddms-internal-flag-pwd', __DIR__])['flags']['ddms-internal-flag-pwd'][0]
+            $this->getMockCommand()->prepareArguments(['--ddms-apps-directory-path', __DIR__])['flags']['ddms-apps-directory-path'][0]
         );
     }
 
-    public function testPrepareArgumentsReturnsArrayWhose_ddms_internal_flag_pwd_FlagsFirstArgumentIsAssignedPathTo_ddms_tmp_DirectoryIf_ddms_internal_flag_pwd_FlagsFirstSpecifiedArgumentIsNotAPathToAnExistingDirectory(): void
+    public function testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathTo_ddms_tmp_DirectoryIfFirstSpecifiedArgumentIsNotAPathToAnExistingDirectory(): void
     {
         $this->assertEquals(
             realpath(str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__)),
-            $this->getMockCommand()->prepareArguments(['--ddms-internal-flag-pwd', 'FooBar' . strval(rand(1000, 9999))])['flags']['ddms-internal-flag-pwd'][0]
+            $this->getMockCommand()->prepareArguments(['--ddms-apps-directory-path', 'FooBar' . strval(rand(1000, 9999))])['flags']['ddms-apps-directory-path'][0]
+        );
+    }
+
+    public function testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathTo_ddms_tmp_DirectoryIf_ddms_apps_directory_path_FlagIsSpecifiedWithNoArguments(): void
+    {
+        $this->assertEquals(
+            realpath(str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__)),
+            $this->getMockCommand()->prepareArguments(['--ddms-apps-directory-path'])['flags']['ddms-apps-directory-path'][0]
+        );
+    }
+
+    public function testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathTo_ddms_tmp_DirectoryIf_ddms_apps_directory_path_FlagIsNotSpecified(): void
+    {
+        $this->assertEquals(
+            realpath(str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__)),
+            $this->getMockCommand()->prepareArguments([])['flags']['ddms-apps-directory-path'][0]
         );
     }
 

--- a/tests/command/AbstractCommandTest.php
+++ b/tests/command/AbstractCommandTest.php
@@ -48,10 +48,19 @@ final class AbstractCommandTest extends TestCase
         );
     }
 
-    public function testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathTo_ddms_tmp_DirectoryIf_ddms_apps_directory_path_FlagIsNotSpecified(): void
+    public function testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathToExpectedDarlingDataManagementSystemAppsDirectoryOr_ddms_tmp_DirectoryIf_ddms_apps_directory_path_FlagIsNotSpecified(): void
     {
+        $expectedDarlingDMSAppsDirectory = strval(realpath(str_replace('vendor' . DIRECTORY_SEPARATOR . 'darling' . DIRECTORY_SEPARATOR . 'ddms' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR .  'command', 'Apps', __DIR__)));
+        $ddmsTmpDirectoryPath = strval(realpath(str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__)));
+        if(file_exists($expectedDarlingDMSAppsDirectory) && is_dir($expectedDarlingDMSAppsDirectory)) {
+            $this->assertEquals(
+                $expectedDarlingDMSAppsDirectory,
+                $this->getMockCommand()->prepareArguments([])['flags']['ddms-apps-directory-path'][0]
+            );
+            return;
+        }
         $this->assertEquals(
-            realpath(str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__)),
+            $ddmsTmpDirectoryPath,
             $this->getMockCommand()->prepareArguments([])['flags']['ddms-apps-directory-path'][0]
         );
     }

--- a/tests/command/NewAppTest.php
+++ b/tests/command/NewAppTest.php
@@ -228,7 +228,7 @@ final class NewAppTest extends TestCase
     private function expectedAppDirectoryPath(array $preparedArguments) : string
     {
         ['flags' => $flags] = $preparedArguments;
-        return ($flags['ddms-internal-flag-pwd'][0] ?? DIRECTORY_SEPARATOR . 'tmp') . DIRECTORY_SEPARATOR . ($flags['name'][0] ?? 'BadTestArgToNewAppNameFlagError');
+        return ($flags['ddms-apps-directory-path'][0] ?? DIRECTORY_SEPARATOR . 'tmp') . DIRECTORY_SEPARATOR . ($flags['name'][0] ?? 'BadTestArgToNewAppNameFlagError');
     }
 
     private function removeDirectory(string $dir): void

--- a/tests/command/NewAppTest.php
+++ b/tests/command/NewAppTest.php
@@ -24,7 +24,6 @@ final class NewAppTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppDirectoryAtPathAssignedTo_ddms_internal_flag_pwd_Flag(): void

--- a/tests/command/NewAppTest.php
+++ b/tests/command/NewAppTest.php
@@ -20,9 +20,11 @@ final class NewAppTest extends TestCase
 
     public function testRunThrowsRuntimeExceptionIfExpectedPathToNewAppDirectoryIsUnavailable() : void
     {
+        $preparedArguments = $this->getNewApp()->prepareArguments(['--new-app', '--name', $this->getRandomAppName()]);
         $this->expectException(\RuntimeException::class);
-        $this->getNewApp()->run($this->getUserInterface(), $this->getNewApp()->prepareArguments(['--new-app', '--name', 'Foo']));
-        $this->getNewApp()->run($this->getUserInterface(), $this->getNewApp()->prepareArguments(['--new-app', '--name', 'Foo']));
+        $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
+        $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
+        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppDirectoryAtPathAssignedTo_ddms_internal_flag_pwd_Flag(): void
@@ -157,6 +159,7 @@ final class NewAppTest extends TestCase
             ),
             file_get_contents($expectedcomponentsPhpFilePath)
         );
+        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunSets_DOMAIN_To_httplocalhost8080_InNewAppsComponentsPhpIf_domain_FlagIsPresentButHasNoArguments(): void
@@ -176,6 +179,7 @@ final class NewAppTest extends TestCase
             ),
             file_get_contents($expectedcomponentsPhpFilePath)
         );
+        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunSets_DOMAIN_To_httplocalhost8080_InNewAppsComponentsPhpIf_domain_FlagIsPresentButFirstArgumentIsNotAValidDomain(): void
@@ -195,6 +199,7 @@ final class NewAppTest extends TestCase
             ),
             file_get_contents($expectedcomponentsPhpFilePath)
         );
+        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunSets_DOMAIN_ToSpecifiedDomainInNewAppsComponentsPhpIf_domain_FlagIsPresentAndFirstArgumentIsAValidDomain(): void
@@ -215,6 +220,7 @@ final class NewAppTest extends TestCase
             ),
             file_get_contents($expectedcomponentsPhpFilePath)
         );
+        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     /**


### PR DESCRIPTION
Code clean up.

`helpFiles`: Updated `helpFiles/help.txt`.

`bin/ddms`: Removed `--ddms-internal-flag-pwd` argument. been replaced by replaces by `--ddms-apps-directory-path`.

`ddms\abstractions\command\AbstractCommand`: Refactored, replaced `--ddms-internal-flag-pwd` with `--ddms-apps-directory-path`.

Implemented the following new tests:

`testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathTo_ddms_tmp_DirectoryIf_ddms_apps_directory_path_FlagIsSpecifiedWithNoArguments()`
    

`testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathTo_ddms_tmp_DirectoryIf_ddms_apps_directory_path_FlagIsNotSpecified()`


Refactored `ddms\classes\command\NewApp` to use `--ddms-apps-directory-path`
instead of `--ddms-internal-flag-pwd.`

Revised` helpFiles/start-server.txt`

Updated `composer`.

Merge branch 'ddms0.0.8-alpha' of `https://github.com/sevidmusic/ddms` into `Commands`

`ddms\abstractions\command\AbstractCommand`: Refactored to look for and use Darling Data Management System's Apps directory as `--ddms-apps-directory-path` if -`-ddms-apps-directory-path` is not specified and the Darling Data Management System's Apps directory can be found. If not, default is still `ddms/tmp` directory. 
Implemented:

`testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathToExpectedDarlingDataManagementSystemAppsDirectoryOr_ddms_tmp_DirectoryIf_ddms_apps_directory_path_FlagIsNotSpecified() `

which replaces 

`testPrepareArgumentsReturnsArrayWhose_ddms_apps_directory_path_FlagsFirstArgumentIsAssignedPathTo_ddms_tmp_DirectoryIf_ddms_apps_directory_path_FlagIsNotSpecified()`

All PhpUnit and PhpStan tests are passing.

