### PR TITLE
ddms0.1.0 alpha | ddms --new-global-response

### DIFF
--- a/FileTemplates/GlobalResponse.php
+++ b/FileTemplates/GlobalResponse.php
@@ -1,12 +1,12 @@
 <?php
 
-/** APP_NAME | GLOBAL_RESPONSE_NAME.php */
+/** _NAME_.php */
 
 use DarlingDataManagementSystem\classes\component\OutputComponent;
 use DarlingDataManagementSystem\classes\component\DynamicOutputComponent;
 
 $appComponentsFactory->buildGlobalResponse(
-    'GLOBAL_RESPONSE_NAME',
-    GLOBAL_RESPONSE_POSITION,
+    '_NAME_',
+    _POSITION_
 );
 

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -12,6 +12,27 @@ class NewGlobalResponse extends AbstractCommand implements Command
 
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
+        $this->validateArguments($preparedArguments);
+        ['flags' => $flags] = $preparedArguments;
+        if(!file_exists($this->determineAppDirectoryPath($flags)) || !is_dir($this->determineAppDirectoryPath($flags))) {
+            throw new RuntimeException('  An App does not exist at' . $this->determineAppDirectoryPath($flags));
+        }
+        return true;
+    }
+
+    /**
+     * @param array <string, array<int, string>> $flags
+     */
+    private function determineAppDirectoryPath(array $flags): string
+    {
+        return  $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['for-app'][0];
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function validateArguments(array $preparedArguments): void
+    {
         ['flags' => $flags] = $preparedArguments;
         if(!isset($flags['name'][0])) {
             throw new RuntimeException('  Please specify a name for the new GlobalResponse.');
@@ -19,11 +40,6 @@ class NewGlobalResponse extends AbstractCommand implements Command
         if(!isset($flags['for-app'][0])) {
             throw new RuntimeException('  Please specify the name of the App to create the new GlobalResponse for');
         }
-        $appDirectoryPath = $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['for-app'][0];
-        if(!file_exists($appDirectoryPath) || !is_dir($appDirectoryPath)) {
-            throw new RuntimeException('  An App does not exist at' . $appDirectoryPath);
-        }
-        return true;
     }
 
 }

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -12,11 +12,7 @@ class NewGlobalResponse extends AbstractCommand implements Command
 
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
-        $this->validateArguments($preparedArguments);
-        ['flags' => $flags] = $preparedArguments;
-        if(!file_exists($this->determineAppDirectoryPath($flags)) || !is_dir($this->determineAppDirectoryPath($flags))) {
-            throw new RuntimeException('  An App does not exist at' . $this->determineAppDirectoryPath($flags));
-        }
+        ['flags' => $flags] = $this->validateArguments($preparedArguments);
         return true;
     }
 
@@ -30,8 +26,9 @@ class NewGlobalResponse extends AbstractCommand implements Command
 
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     * @return array{"flags": array<string, array<int, string>>, "options": array<int, string>}
      */
-    private function validateArguments(array $preparedArguments): void
+    private function validateArguments(array $preparedArguments): array
     {
         ['flags' => $flags] = $preparedArguments;
         if(!isset($flags['name'][0])) {
@@ -40,6 +37,10 @@ class NewGlobalResponse extends AbstractCommand implements Command
         if(!isset($flags['for-app'][0])) {
             throw new RuntimeException('  Please specify the name of the App to create the new GlobalResponse for');
         }
+        if(!file_exists($this->determineAppDirectoryPath($flags)) || !is_dir($this->determineAppDirectoryPath($flags))) {
+            throw new RuntimeException('  An App does not exist at' . $this->determineAppDirectoryPath($flags));
+        }
+        return $preparedArguments;
     }
 
 }

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -14,6 +14,7 @@ class NewGlobalResponse extends AbstractCommand implements Command
     {
         ['flags' => $flags] = $this->validateArguments($preparedArguments);
         $template = strval(file_get_contents($this->pathToGlobalResponseTemplate()));
+#var_dump(($flags['position'][0] ?? 'No Position Set'));
         $content = str_replace(['_NAME_', '_POSITION_'], [$flags['name'][0], ($flags['position'][0] ?? '0')], $template);
         return boolval(file_put_contents($this->pathToNewGlobalResponse($flags), $content));
     }
@@ -51,6 +52,9 @@ class NewGlobalResponse extends AbstractCommand implements Command
         }
         if(!file_exists($this->determineAppDirectoryPath($flags)) || !is_dir($this->determineAppDirectoryPath($flags))) {
             throw new RuntimeException('  An App does not exist at' . $this->determineAppDirectoryPath($flags));
+        }
+        if(isset($flags['position'][0]) && !is_numeric($flags['position'][0])) {
+            throw new RuntimeException('  Please specify a numeric position for the new GlobalResponse. For example `--position 1`.');
         }
         return $preparedArguments;
     }

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -14,7 +14,6 @@ class NewGlobalResponse extends AbstractCommand implements Command
     {
         ['flags' => $flags] = $this->validateArguments($preparedArguments);
         $template = strval(file_get_contents($this->pathToGlobalResponseTemplate()));
-#var_dump(($flags['position'][0] ?? 'No Position Set'));
         $content = str_replace(['_NAME_', '_POSITION_'], [$flags['name'][0], ($flags['position'][0] ?? '0')], $template);
         return boolval(file_put_contents($this->pathToNewGlobalResponse($flags), $content));
     }

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -13,7 +13,27 @@ class NewGlobalResponse extends AbstractCommand implements Command
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
         ['flags' => $flags] = $this->validateArguments($preparedArguments);
-        return true;
+        $template = strval(file_get_contents($this->pathToGlobalResponseTemplate()));
+        $content = str_replace(['_NAME_', '_POSITION_'], [$flags['name'][0], ($flags['position'][0] ?? '0')], $template);
+        return boolval(file_put_contents($this->pathToNewGlobalResponse($flags), $content));
+    }
+
+    private function pathToGlobalResponseTemplate(): string
+    {
+        $templatePath = str_replace('ddms' . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'command', 'FileTemplates', __DIR__) . DIRECTORY_SEPARATOR . 'GlobalResponse.php';
+        if(!file_exists($templatePath)) {
+            throw new RuntimeException('Error: The GlobalResponse.php file template is missing! You will not be able to create new GlobalResponses until the GlobalResponse.php template is restored at FileTemplates/GlobalResponse.php');
+        }
+        return $templatePath;
+
+    }
+
+    /**
+     * @param array<string,array<int,string>> $flags
+     */
+    private function pathToNewGlobalResponse(array $flags): string
+    {
+        return $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['for-app'][0] . DIRECTORY_SEPARATOR . 'Responses' . DIRECTORY_SEPARATOR . $flags['name'][0] . '.php';
     }
 
     /**

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ddms\classes\command;
+
+use ddms\interfaces\command\Command;
+use ddms\abstractions\command\AbstractCommand;
+use ddms\interfaces\ui\UserInterface;
+use \RuntimeException;
+
+class NewGlobalResponse extends AbstractCommand implements Command
+{
+
+    public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
+    {
+        ['flags' => $flags] = $preparedArguments;
+        if(!isset($flags['name'][0])) {
+            throw new RuntimeException('  Please specify a name for the new GlobalResponse.');
+        }
+        if(!isset($flags['for-app'][0])) {
+            throw new RuntimeException('  Please specify the name of the App to create the new GlobalResponse for');
+        }
+        $appDirectoryPath = $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['for-app'][0];
+        if(!file_exists($appDirectoryPath) || !is_dir($appDirectoryPath)) {
+            throw new RuntimeException('  An App does not exist at' . $appDirectoryPath);
+        }
+        return true;
+    }
+
+}

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -52,6 +52,9 @@ class NewGlobalResponse extends AbstractCommand implements Command
         if(!file_exists($this->determineAppDirectoryPath($flags)) || !is_dir($this->determineAppDirectoryPath($flags))) {
             throw new RuntimeException('  An App does not exist at' . $this->determineAppDirectoryPath($flags));
         }
+        if(file_exists($this->pathToNewGlobalResponse($flags))) {
+            throw new RuntimeException('  Please specify a unique name for the new GlobalResponse');
+        }
         if(isset($flags['position'][0]) && !is_numeric($flags['position'][0])) {
             throw new RuntimeException('  Please specify a numeric position for the new GlobalResponse. For example `--position 1`.');
         }

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -17,14 +17,6 @@ class NewGlobalResponse extends AbstractCommand implements Command
     }
 
     /**
-     * @param array <string, array<int, string>> $flags
-     */
-    private function determineAppDirectoryPath(array $flags): string
-    {
-        return  $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['for-app'][0];
-    }
-
-    /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      * @return array{"flags": array<string, array<int, string>>, "options": array<int, string>}
      */
@@ -42,5 +34,14 @@ class NewGlobalResponse extends AbstractCommand implements Command
         }
         return $preparedArguments;
     }
+
+    /**
+     * @param array <string, array<int, string>> $flags
+     */
+    private function determineAppDirectoryPath(array $flags): string
+    {
+        return  $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['for-app'][0];
+    }
+
 
 }

--- a/ddms/classes/command/NewGlobalResponse.php
+++ b/ddms/classes/command/NewGlobalResponse.php
@@ -46,6 +46,9 @@ class NewGlobalResponse extends AbstractCommand implements Command
         if(!isset($flags['name'][0])) {
             throw new RuntimeException('  Please specify a name for the new GlobalResponse.');
         }
+        if(!ctype_alnum($flags['name'][0])) {
+            throw new RuntimeException('  Please specify an alphanumeric name for the new GlobalResponse.');
+        }
         if(!isset($flags['for-app'][0])) {
             throw new RuntimeException('  Please specify the name of the App to create the new GlobalResponse for');
         }

--- a/helpFiles/help.txt
+++ b/helpFiles/help.txt
@@ -1,17 +1,28 @@
 
-  `ddms [--help] [--start-server] [--view-active-servers]`
+  ```
+    ddms [--help] [--start-server] [--view-active-servers] [--new-app]
+         [--new-global-response] [--ddms-apps-directory-path]`
+  ```
+
+  Description:
 
   ddms is a command line utility designed to aide in the development process
   with the Darling Data Management System. ddms provides a number of commands
   that can be used to perform common development tasks.
 
-  ddms is still under development. At the moment, the following commands are
-  available:
+  Flags:
 
-  `ddms --help [FLAG]`
-  `ddms --start-server [--port] [--root-dir] [--php-ini] [--open-in-browser]`
-  `ddms --view-active-servers`
-  `ddms --new-app --name [--domain]`
+  `ddms --help [FLAG]`         Show this help message, or the appropriate help
+                               message for the specified FLAG.
+
+  `ddms --start-server`        Start a development server.
+
+  `ddms --view-active-servers` Show active development servers.
+
+  `ddms --new-app`             Create a new Darling Data Management System App.
+
+  `ddms --new-global-response` Create a new GlobalResponse for a Darling Data
+                               Management System App.
 
   For more information about a specific command use `ddms --help [FLAG]`. For
   example, to get help information about the --new-app command use either of
@@ -20,7 +31,7 @@
     `ddms --help --new-app`
     `ddms --help new-app`
 
-  For more information go to:
+  For more information about ddms go to:
   https://github.com/sevidmusic/ddms
 
   For more information about the Darling Data Management System go to:

--- a/tests/command/NewAppTest.php
+++ b/tests/command/NewAppTest.php
@@ -211,6 +211,22 @@ final class NewAppTest extends TestCase
         );
     }
 
+    private function getNewApp(): NewApp
+    {
+        if(!isset($this->newApp)) {
+            $this->newApp = new NewApp();
+        }
+        return $this->newApp;
+    }
+
+    private function getUserInterface(): UserInterface
+    {
+        if(!isset($this->ui)) {
+            $this->ui = new CommandLineUI();
+        }
+        return $this->ui;
+    }
+
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */
@@ -238,28 +254,12 @@ final class NewAppTest extends TestCase
         }
     }
 
-    private function getNewApp(): NewApp
-    {
-        if(!isset($this->newApp)) {
-            $this->newApp = new NewApp();
-        }
-        return $this->newApp;
-    }
-
-    private function getUserInterface(): UserInterface
-    {
-        if(!isset($this->ui)) {
-            $this->ui = new CommandLineUI();
-        }
-        return $this->ui;
-    }
-
     public static function registerAppName(string $appName): void
     {
         array_push(self::$createdApps, $appName);
     }
 
-    private function getRandomAppName(): string
+    private static function getRandomAppName(): string
     {
         $appName = 'App' . strval(rand(1000,9999));
         self::registerAppName($appName);

--- a/tests/command/NewAppTest.php
+++ b/tests/command/NewAppTest.php
@@ -254,7 +254,7 @@ final class NewAppTest extends TestCase
         }
     }
 
-    public static function registerAppName(string $appName): void
+    private static function registerAppName(string $appName): void
     {
         array_push(self::$createdApps, $appName);
     }

--- a/tests/command/NewAppTest.php
+++ b/tests/command/NewAppTest.php
@@ -6,13 +6,14 @@ use PHPUnit\Framework\TestCase;
 use ddms\classes\command\NewApp;
 use ddms\classes\ui\CommandLineUI;
 use ddms\interfaces\ui\UserInterface;
+use tests\traits\TestsCreateApps;
 
 final class NewAppTest extends TestCase
 {
+
+    use TestsCreateApps;
     private UserInterface $ui;
     private NewApp $newApp;
-    /** @var array <int, string> $createdApps */
-    private static $createdApps = [];
 
     public function testRunThrowsRuntimeExceptionIf_name_IsNotSpecified() : void
     {
@@ -225,54 +226,6 @@ final class NewAppTest extends TestCase
             $this->ui = new CommandLineUI();
         }
         return $this->ui;
-    }
-
-    /**
-     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
-     */
-    private static function expectedAppDirectoryPath(array $preparedArguments) : string
-    {
-        ['flags' => $flags] = $preparedArguments;
-        $path = ($flags['ddms-apps-directory-path'][0] ?? DIRECTORY_SEPARATOR . 'tmp') . DIRECTORY_SEPARATOR . ($flags['name'][0] ?? 'BadTestArgToNewAppNameFlagError');
-        return $path;
-    }
-
-    private static function removeDirectory(string $dir): void
-    {
-        if (is_dir($dir)) {
-            $contents = scandir($dir);
-            $contents = (is_array($contents) ? $contents : []);
-            foreach ($contents as $item) {
-                if ($item != "." && $item != "..") {
-                    $itemPath = $dir . DIRECTORY_SEPARATOR . $item;
-                    (is_dir($itemPath) === true && is_link($itemPath) === false)
-                        ? self::removeDirectory($itemPath)
-                        : unlink($itemPath);
-                }
-            }
-            rmdir($dir);
-        }
-    }
-
-    private static function registerAppName(string $appName): void
-    {
-        array_push(self::$createdApps, $appName);
-    }
-
-    private static function getRandomAppName(): string
-    {
-        $appName = 'App' . strval(rand(1000,9999));
-        self::registerAppName($appName);
-        return $appName;
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        $newApp = new NewApp();
-        foreach(self::$createdApps as $appName) {
-            $preparedArguments = $newApp->prepareArguments(['--name', $appName]);
-            self::removeDirectory(self::expectedAppDirectoryPath($preparedArguments));
-        }
     }
 
 }

--- a/tests/command/NewAppTest.php
+++ b/tests/command/NewAppTest.php
@@ -28,7 +28,7 @@ final class NewAppTest extends TestCase
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
     }
 
-    public function testRunCreatesNewAppDirectoryAtPathAssignedTo_ddms_internal_flag_pwd_Flag(): void
+    public function testRunCreatesNewAppDirectoryAtPathAssignedTo_ddms_apps_directory_path_Flag(): void
     {
         $name = $this->getRandomAppName();
         $argv = ['--new-app', '--name', $name ];

--- a/tests/command/NewAppTest.php
+++ b/tests/command/NewAppTest.php
@@ -11,6 +11,8 @@ final class NewAppTest extends TestCase
 {
     private UserInterface $ui;
     private NewApp $newApp;
+    /** @var array <int, string> $createdApps */
+    private static $createdApps = [];
 
     public function testRunThrowsRuntimeExceptionIf_name_IsNotSpecified() : void
     {
@@ -33,9 +35,8 @@ final class NewAppTest extends TestCase
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
-        $this->assertTrue(file_exists($this->expectedAppDirectoryPath($preparedArguments)));
-        $this->assertTrue(is_dir($this->expectedAppDirectoryPath($preparedArguments)));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
+        $this->assertTrue(file_exists(self::expectedAppDirectoryPath($preparedArguments)));
+        $this->assertTrue(is_dir(self::expectedAppDirectoryPath($preparedArguments)));
     }
 
     public function testRunCreatesNewAppsCssDirectory(): void
@@ -44,11 +45,10 @@ final class NewAppTest extends TestCase
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedCssDirectoryPath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'css';
+        $expectedCssDirectoryPath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'css';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertTrue(file_exists($expectedCssDirectoryPath));
         $this->assertTrue(is_dir($expectedCssDirectoryPath));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppsJsDirectory(): void
@@ -57,11 +57,10 @@ final class NewAppTest extends TestCase
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedJsDirectoryPath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'js';
+        $expectedJsDirectoryPath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'js';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertTrue(file_exists($expectedJsDirectoryPath));
         $this->assertTrue(is_dir($expectedJsDirectoryPath));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppsDynamicOutputDirectory(): void
@@ -70,11 +69,10 @@ final class NewAppTest extends TestCase
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedDynamicOutputDirectoryPath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'DynamicOutput';
+        $expectedDynamicOutputDirectoryPath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'DynamicOutput';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertTrue(file_exists($expectedDynamicOutputDirectoryPath));
         $this->assertTrue(is_dir($expectedDynamicOutputDirectoryPath));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppsResourcesDirectory(): void
@@ -83,11 +81,10 @@ final class NewAppTest extends TestCase
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedresourcesDirectoryPath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'resources';
+        $expectedresourcesDirectoryPath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'resources';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertTrue(file_exists($expectedresourcesDirectoryPath));
         $this->assertTrue(is_dir($expectedresourcesDirectoryPath));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppsResponsesDirectory(): void
@@ -96,11 +93,10 @@ final class NewAppTest extends TestCase
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedresponsesDirectoryPath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Responses';
+        $expectedresponsesDirectoryPath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Responses';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertTrue(file_exists($expectedresponsesDirectoryPath));
         $this->assertTrue(is_dir($expectedresponsesDirectoryPath));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppsRequestsDirectory(): void
@@ -109,11 +105,10 @@ final class NewAppTest extends TestCase
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedrequestsDirectoryPath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Requests';
+        $expectedrequestsDirectoryPath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Requests';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertTrue(file_exists($expectedrequestsDirectoryPath));
         $this->assertTrue(is_dir($expectedrequestsDirectoryPath));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppsOutputComponentsDirectory(): void
@@ -122,11 +117,10 @@ final class NewAppTest extends TestCase
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedoutputComponentsDirectoryPath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'OutputComponents';
+        $expectedoutputComponentsDirectoryPath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'OutputComponents';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertTrue(file_exists($expectedoutputComponentsDirectoryPath));
         $this->assertTrue(is_dir($expectedoutputComponentsDirectoryPath));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunCreatesNewAppsComponentsPhpFile(): void
@@ -135,19 +129,18 @@ final class NewAppTest extends TestCase
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedcomponentsPhpFilePath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
+        $expectedcomponentsPhpFilePath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertTrue(file_exists($expectedcomponentsPhpFilePath));
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunSets_DOMAIN_To_httplocalhost8080_InNewAppsComponentsPhpIf_domain_FlagIsNotPresent(): void
     {
-        $name = 'Foo' . strval(rand(1000,9999));
+        $name = $this->getRandomAppName();
         $argv = ['--new-app', '--name', $name ];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedcomponentsPhpFilePath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
+        $expectedcomponentsPhpFilePath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
         $expectedComponentsPhpFileTemplatePath = str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'FileTemplates', __DIR__) . DIRECTORY_SEPARATOR . 'Components.php';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertEquals(
@@ -158,16 +151,15 @@ final class NewAppTest extends TestCase
             ),
             file_get_contents($expectedcomponentsPhpFilePath)
         );
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunSets_DOMAIN_To_httplocalhost8080_InNewAppsComponentsPhpIf_domain_FlagIsPresentButHasNoArguments(): void
     {
-        $name = 'Foo' . strval(rand(1000,9999));
+        $name = $this->getRandomAppName();
         $argv = ['--new-app', '--name', $name, '--domain'];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedcomponentsPhpFilePath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
+        $expectedcomponentsPhpFilePath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
         $expectedComponentsPhpFileTemplatePath = str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'FileTemplates', __DIR__) . DIRECTORY_SEPARATOR . 'Components.php';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertEquals(
@@ -178,16 +170,15 @@ final class NewAppTest extends TestCase
             ),
             file_get_contents($expectedcomponentsPhpFilePath)
         );
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunSets_DOMAIN_To_httplocalhost8080_InNewAppsComponentsPhpIf_domain_FlagIsPresentButFirstArgumentIsNotAValidDomain(): void
     {
-        $name = 'Foo' . strval(rand(1000,9999));
+        $name = $this->getRandomAppName();
         $argv = ['--new-app', '--name', $name, '--domain', 'FooBar' . strval(rand(1000, 9999))];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedcomponentsPhpFilePath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
+        $expectedcomponentsPhpFilePath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
         $expectedComponentsPhpFileTemplatePath = str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'FileTemplates', __DIR__) . DIRECTORY_SEPARATOR . 'Components.php';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertEquals(
@@ -198,17 +189,16 @@ final class NewAppTest extends TestCase
             ),
             file_get_contents($expectedcomponentsPhpFilePath)
         );
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     public function testRunSets_DOMAIN_ToSpecifiedDomainInNewAppsComponentsPhpIf_domain_FlagIsPresentAndFirstArgumentIsAValidDomain(): void
     {
-        $name = 'Foo' . strval(rand(1000,9999));
+        $name = $this->getRandomAppName();
         $domain = 'http://localhost:' . strval(rand(8000, 8999));
         $argv = ['--new-app', '--name', $name, '--domain', $domain];
         $preparedArguments = $this->getNewApp()->prepareArguments($argv);
         ['flags' => $flags] = $preparedArguments;
-        $expectedcomponentsPhpFilePath = $this->expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
+        $expectedcomponentsPhpFilePath = self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php';
         $expectedComponentsPhpFileTemplatePath = str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'FileTemplates', __DIR__) . DIRECTORY_SEPARATOR . 'Components.php';
         $this->getNewApp()->run($this->getUserInterface(), $preparedArguments);
         $this->assertEquals(
@@ -219,19 +209,19 @@ final class NewAppTest extends TestCase
             ),
             file_get_contents($expectedcomponentsPhpFilePath)
         );
-        $this->removeDirectory($this->expectedAppDirectoryPath($preparedArguments));
     }
 
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */
-    private function expectedAppDirectoryPath(array $preparedArguments) : string
+    private static function expectedAppDirectoryPath(array $preparedArguments) : string
     {
         ['flags' => $flags] = $preparedArguments;
-        return ($flags['ddms-apps-directory-path'][0] ?? DIRECTORY_SEPARATOR . 'tmp') . DIRECTORY_SEPARATOR . ($flags['name'][0] ?? 'BadTestArgToNewAppNameFlagError');
+        $path = ($flags['ddms-apps-directory-path'][0] ?? DIRECTORY_SEPARATOR . 'tmp') . DIRECTORY_SEPARATOR . ($flags['name'][0] ?? 'BadTestArgToNewAppNameFlagError');
+        return $path;
     }
 
-    private function removeDirectory(string $dir): void
+    private static function removeDirectory(string $dir): void
     {
         if (is_dir($dir)) {
             $contents = scandir($dir);
@@ -240,7 +230,7 @@ final class NewAppTest extends TestCase
                 if ($item != "." && $item != "..") {
                     $itemPath = $dir . DIRECTORY_SEPARATOR . $item;
                     (is_dir($itemPath) === true && is_link($itemPath) === false)
-                        ? $this->removeDirectory($itemPath)
+                        ? self::removeDirectory($itemPath)
                         : unlink($itemPath);
                 }
             }
@@ -264,8 +254,25 @@ final class NewAppTest extends TestCase
         return $this->ui;
     }
 
+    public static function registerAppName(string $appName): void
+    {
+        array_push(self::$createdApps, $appName);
+    }
+
     private function getRandomAppName(): string
     {
-        return 'App' . strval(rand(1000,9999));
+        $appName = 'App' . strval(rand(1000,9999));
+        self::registerAppName($appName);
+        return $appName;
     }
+
+    public static function tearDownAfterClass(): void
+    {
+        $newApp = new NewApp();
+        foreach(self::$createdApps as $appName) {
+            $preparedArguments = $newApp->prepareArguments(['--name', $appName]);
+            self::removeDirectory(self::expectedAppDirectoryPath($preparedArguments));
+        }
+    }
+
 }

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -85,6 +85,17 @@ final class NewGlobalResponseTest extends TestCase
         $this->assertEquals($this->determineExpectedGlobalResponsePhpContent($preparedArguments), file_get_contents($this->expectedGlobalResponsePath($preparedArguments)));
     }
 
+    public function testRunThrowsRuntimeExceptionIfGlobalResponseAlreadyExists(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $responseName = $appName . 'GlobalResponse';
+        $newGlobalResponse = new NewGlobalResponse();
+        $preparedArguments = $newGlobalResponse->prepareArguments(['--name', $responseName, '--for-app', $appName]);
+        $newGlobalResponse->run(new CommandLineUI(), $preparedArguments);
+        $this->expectException(RuntimeException::class);
+        $newGlobalResponse->run(new CommandLineUI(), $preparedArguments);
+    }
+
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -74,11 +74,16 @@ final class NewGlobalResponseTest extends TestCase
         $this->expectException(RuntimeException::class);
         $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--name', $responseName, '--for-app', $appName, '--position', 'FooBarBaz']));
     }
-/*
+
     public function testRunSetsPositionToSpecifiedPositionIfSpecifiedPositionIsNumeric(): void
     {
+        $appName = $this->createTestAppReturnName();
+        $responseName = $appName . 'GlobalResponse';
+        $newGlobalResponse = new NewGlobalResponse();
+        $preparedArguments = $newGlobalResponse->prepareArguments(['--name', $responseName, '--for-app', $appName, '--position', '420']);
+        $newGlobalResponse->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedGlobalResponsePhpContent($preparedArguments), file_get_contents($this->expectedGlobalResponsePath($preparedArguments)));
     }
-*/
 
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -107,6 +107,16 @@ final class NewGlobalResponseTest extends TestCase
         $newGlobalResponse->run(new CommandLineUI(), $preparedArguments);
     }
 
+    public function testRunSetsNameToSpecifiedNameIfSpecifiedNameIsAlphaNumeric(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $responseName = $appName . 'GlobalResponse';
+        $newGlobalResponse = new NewGlobalResponse();
+        $preparedArguments = $newGlobalResponse->prepareArguments(['--name', $responseName, '--for-app', $appName]);
+        $newGlobalResponse->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedGlobalResponsePhpContent($preparedArguments), file_get_contents($this->expectedGlobalResponsePath($preparedArguments)));
+    }
+
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -102,7 +102,7 @@ final class NewGlobalResponseTest extends TestCase
         $appName = $this->createTestAppReturnName();
         $responseName = $appName . 'GlobalResponse';
         $newGlobalResponse = new NewGlobalResponse();
-        $preparedArguments = $newGlobalResponse->prepareArguments(['--name', $responseName . '_-_FOO', '--for-app', $appName]);
+        $preparedArguments = $newGlobalResponse->prepareArguments(['--name', $responseName . '!@#$%^&*()_+=-\][\';"\\,.', '--for-app', $appName]);
         $this->expectException(RuntimeException::class);
         $newGlobalResponse->run(new CommandLineUI(), $preparedArguments);
     }

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -56,14 +56,6 @@ final class NewGlobalResponseTest extends TestCase
         $this->assertEquals($this->determineExpectedGlobalResponsePhpContent($preparedArguments), $this->getNewGlobalResponseContent($preparedArguments));
     }
 
-    /**
-     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
-     */
-    private function getNewGlobalResponseContent($preparedArguments): string
-    {
-        return strval(file_get_contents($this->expectedGlobalResponsePath($preparedArguments)));
-    }
-
     public function testRunSetsPositionTo_0_IfPositionIsSpecifiedWithNoValue(): void
     {
         $appName = $this->createTestAppReturnName();
@@ -87,6 +79,15 @@ final class NewGlobalResponseTest extends TestCase
     {
     }
 */
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function getNewGlobalResponseContent($preparedArguments): string
+    {
+        return strval(file_get_contents($this->expectedGlobalResponsePath($preparedArguments)));
+    }
+
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -7,9 +7,12 @@ use ddms\classes\command\NewGlobalResponse;
 use ddms\classes\ui\CommandLineUI;
 use ddms\interfaces\ui\UserInterface;
 use \RuntimeException;
+use tests\traits\TestsCreateApps;
 
 final class NewGlobalResponseTest extends TestCase
 {
+
+    use TestsCreateApps;
 
     public function testRunThrowsRuntimeExceptionIf_name_IsNotSpecified(): void
     {

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -76,10 +76,7 @@ final class NewGlobalResponseTest extends TestCase
 
     public function testRunThrowsRuntimeExceptionIfSpecifiedPositionIsNotNumeric(): void
     {
-        $appName = self::getRandomAppName();
-        $newApp = new NewApp();
-        $newAppPreparedArguments = $newApp->prepareArguments(['--name', $appName]);
-        $newApp->run(new CommandLineUI(), $newAppPreparedArguments);
+        $appName = $this->createTestAppReturnName();
         $responseName = $appName . 'GlobalResponse';
         $newGlobalResponse = new NewGlobalResponse();
         $this->expectException(RuntimeException::class);

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace tests\command;
+
+use PHPUnit\Framework\TestCase;
+use ddms\classes\command\NewGlobalResponse;
+use ddms\classes\ui\CommandLineUI;
+use ddms\interfaces\ui\UserInterface;
+use \RuntimeException;
+
+final class NewGlobalResponseTest extends TestCase
+{
+
+    public function testRunThrowsRuntimeExceptionIf_name_IsNotSpecified(): void
+    {
+        $newGlobalResponse = new NewGlobalResponse();
+        $this->expectException(RuntimeException::class);
+        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--new-global-response']));
+    }
+
+    public function testRunThrowsRuntimeExceptionIf_for_app_IsNotSpecified(): void
+    {
+        $newGlobalResponse = new NewGlobalResponse();
+        $this->expectException(RuntimeException::class);
+        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--new-global-response', '--name', 'Foo']));
+    }
+
+    public function testRunThrowsRuntimeExceptionIfSpecifiedAppDoesNotExist(): void
+    {
+        $newGlobalResponse = new NewGlobalResponse();
+        $this->expectException(RuntimeException::class);
+        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--new-global-response', '--name', 'Foo', '--for-app', 'Baz' . strval(rand(10000,9999))]));
+    }
+
+}

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -96,6 +96,17 @@ final class NewGlobalResponseTest extends TestCase
         $newGlobalResponse->run(new CommandLineUI(), $preparedArguments);
     }
 
+    public function testRunThrowsRuntimeExpceptionIfSpecifiedNameIsNotAlphaNumeric(): void
+    {
+        #ctype_alnum($string)
+        $appName = $this->createTestAppReturnName();
+        $responseName = $appName . 'GlobalResponse';
+        $newGlobalResponse = new NewGlobalResponse();
+        $preparedArguments = $newGlobalResponse->prepareArguments(['--name', $responseName . '_-_FOO', '--for-app', $appName]);
+        $this->expectException(RuntimeException::class);
+        $newGlobalResponse->run(new CommandLineUI(), $preparedArguments);
+    }
+
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */

--- a/tests/command/NewGlobalResponseTest.php
+++ b/tests/command/NewGlobalResponseTest.php
@@ -3,6 +3,7 @@
 namespace tests\command;
 
 use PHPUnit\Framework\TestCase;
+use ddms\classes\command\NewApp;
 use ddms\classes\command\NewGlobalResponse;
 use ddms\classes\ui\CommandLineUI;
 use ddms\interfaces\ui\UserInterface;
@@ -18,21 +19,40 @@ final class NewGlobalResponseTest extends TestCase
     {
         $newGlobalResponse = new NewGlobalResponse();
         $this->expectException(RuntimeException::class);
-        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--new-global-response']));
+        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments([]));
     }
 
     public function testRunThrowsRuntimeExceptionIf_for_app_IsNotSpecified(): void
     {
         $newGlobalResponse = new NewGlobalResponse();
         $this->expectException(RuntimeException::class);
-        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--new-global-response', '--name', 'Foo']));
+        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--name', 'Foo']));
     }
 
     public function testRunThrowsRuntimeExceptionIfSpecifiedAppDoesNotExist(): void
     {
         $newGlobalResponse = new NewGlobalResponse();
         $this->expectException(RuntimeException::class);
-        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--new-global-response', '--name', 'Foo', '--for-app', 'Baz' . strval(rand(10000,9999))]));
+        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--name', 'Foo', '--for-app', 'Baz' . strval(rand(10000,9999))]));
     }
 
+    public function testRunCreatesNewGlobalResponseForSpecifiedApp(): void
+    {
+        $appName = self::getRandomAppName();
+        $newApp = new NewApp();
+        $newAppPreparedArguments = $newApp->prepareArguments(['--name', $appName]);
+        $newApp->run(new CommandLineUI(), $newAppPreparedArguments);
+        $responseName = $appName . 'GlobalResponse';
+        $newGlobalResponse = new NewGlobalResponse();
+        $newGlobalResponse->run(new CommandLineUI(), $newGlobalResponse->prepareArguments(['--name', $responseName, '--for-app', $appName]));
+        $this->assertTrue(file_exists($this->expectedGlobalResponsePath($newAppPreparedArguments, $responseName)));
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function expectedGlobalResponsePath(array $preparedArguments, string $responseName): string
+    {
+        return self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Responses' . DIRECTORY_SEPARATOR . $responseName . '.php';
+    }
 }

--- a/tests/command/StartServerTest.php
+++ b/tests/command/StartServerTest.php
@@ -249,7 +249,7 @@ final class StartServerTest extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        var_dump(shell_exec('/usr/bin/killall firefox'));
+        exec('/usr/bin/killall firefox');
     }
 
 }

--- a/tests/command/StartServerTest.php
+++ b/tests/command/StartServerTest.php
@@ -247,9 +247,4 @@ final class StartServerTest extends TestCase
         );
     }
 
-    public static function tearDownAfterClass(): void
-    {
-        exec('/usr/bin/killall firefox');
-    }
-
 }

--- a/tests/command/StartServerTest.php
+++ b/tests/command/StartServerTest.php
@@ -247,6 +247,9 @@ final class StartServerTest extends TestCase
         );
     }
 
-
+    public static function tearDownAfterClass(): void
+    {
+        var_dump(shell_exec('/usr/bin/killall firefox'));
+    }
 
 }

--- a/tests/traits/TestsCreateApps.php
+++ b/tests/traits/TestsCreateApps.php
@@ -18,7 +18,7 @@ trait TestsCreateApps
     protected static function expectedAppDirectoryPath(array $preparedArguments) : string
     {
         ['flags' => $flags] = $preparedArguments;
-        $path = ($flags['ddms-apps-directory-path'][0] ?? DIRECTORY_SEPARATOR . 'tmp') . DIRECTORY_SEPARATOR . ($flags['name'][0] ?? 'BadTestArgToNewAppNameFlagError');
+        $path = ($flags['ddms-apps-directory-path'][0] ?? DIRECTORY_SEPARATOR . 'tmp') . DIRECTORY_SEPARATOR . ($flags['for-app'][0] ?? ($flags['name'][0] ?? 'BadTestArgToNewAppNameFlagError'));
         return $path;
     }
 

--- a/tests/traits/TestsCreateApps.php
+++ b/tests/traits/TestsCreateApps.php
@@ -46,7 +46,7 @@ trait TestsCreateApps
 
     protected static function getRandomAppName(): string
     {
-        $appName = 'App' . strval(rand(1000,9999));
+        $appName = 'App' . strval(rand(0, PHP_INT_MAX));
         self::registerAppName($appName);
         return $appName;
     }

--- a/tests/traits/TestsCreateApps.php
+++ b/tests/traits/TestsCreateApps.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace tests\traits;
+
+use ddms\classes\command\NewApp;
+use ddms\classes\ui\CommandLineUI;
+use ddms\interfaces\ui\UserInterface;
+
+trait TestsCreateApps
+{
+
+    /** @var array <int, string> $createdApps */
+    protected static $createdApps = [];
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    protected static function expectedAppDirectoryPath(array $preparedArguments) : string
+    {
+        ['flags' => $flags] = $preparedArguments;
+        $path = ($flags['ddms-apps-directory-path'][0] ?? DIRECTORY_SEPARATOR . 'tmp') . DIRECTORY_SEPARATOR . ($flags['name'][0] ?? 'BadTestArgToNewAppNameFlagError');
+        return $path;
+    }
+
+    protected static function removeDirectory(string $dir): void
+    {
+        if (is_dir($dir)) {
+            $contents = scandir($dir);
+            $contents = (is_array($contents) ? $contents : []);
+            foreach ($contents as $item) {
+                if ($item != "." && $item != "..") {
+                    $itemPath = $dir . DIRECTORY_SEPARATOR . $item;
+                    (is_dir($itemPath) === true && is_link($itemPath) === false)
+                        ? self::removeDirectory($itemPath)
+                        : unlink($itemPath);
+                }
+            }
+            rmdir($dir);
+        }
+    }
+
+    protected static function registerAppName(string $appName): void
+    {
+        array_push(self::$createdApps, $appName);
+    }
+
+    protected static function getRandomAppName(): string
+    {
+        $appName = 'App' . strval(rand(1000,9999));
+        self::registerAppName($appName);
+        return $appName;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $newApp = new NewApp();
+        foreach(self::$createdApps as $appName) {
+            $preparedArguments = $newApp->prepareArguments(['--name', $appName]);
+            self::removeDirectory(self::expectedAppDirectoryPath($preparedArguments));
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
Finished initial implementation of:

`ddms --new-global-response --for-app [--name] [--position]`

Description:

Create a new GlobalResponse for the specified App.

Flags:

`--for-app` The name of the App to create the GlobalResponse for.

`--name` A name to assign to the new GlobalResponse.

`[--position]` A position to assign to the new GlobalResponse. Defaults to 0.

Examples:

```
  ddms --new-global-response --for-app HelloWorld --name Foo

  ddms --new-global-response --for-app HelloWorld --name Bar --position 3
```

### Overview of changes:

`ddms\classes\command\NewGlobalResponse`: Began development of

`ddms\classes\command\NewGlobalResponse`: Implemented the following
`tests`:

```
testRunThrowsRuntimeExceptionIf_name_IsNotSpecified()

testRunThrowsRuntimeExceptionIf_for_app_IsNotSpecified()

testRunThrowsRuntimeExceptionIfSpecifiedAppDoesNotExist()
```

`ddms\classes\command\NewApp`: Code clean up. Refactored to insure all

Apps created by tests are removed.


`ddms\classes\command\NewApp`: Code clean up. Refactored `tests\command\NewAppTest`
to use new `tests\traits\TestsCreateApps` trait to handle logic that will be common
to all Test classes whose tests create a Darling Data Managment System App.
This new test trait will also handle tear down so long as App's are registered via
`TestsCreateApps::registerApp()`. This trait will make it easier to clean up any
Apps that were created during tests, and also provide a single place to define
methods common to Tests classes that test Commands that create Apps, or create
files/directories/components for Apps. All PhpUnit tests and PhpStan tests are
still passing.


`tests\command\StartServerTest`: refactored to kill all firefox instances that were
started by xdg-open by test calls to StartServer->run(). This change is specific to
my testing enviornment, it was getting annoying having tons of browser tabs
open each time I ran tests during development.

`tests\command\NewGlobalResponseTest`: Refactored to use `tests\traits\TestsCreateApps` trait.


`tests\traits\TestsCreateApps`: Refactored so randomly generated App names use a
larger sample of ints to select from to make App names more random for tests.
Had a few collisions...these dont need to be cryptographically secure, just
random enough that the Apps created during tests are highly unlikely to have
the same name generated for them before tear down can clean them up.


`tests\command\StartServerTest`: Removed tear down logic that killed browser,
killing the browser turned out to be more annoying than not killing it, firefox
sometimes resurrects itself after being killed, not sure why, but i ended up
having to close firefox manually anyway....



`ddms\classes\command\NewGlobalResponse`: Continued development of
ddms\classes\command\NewGlobalResponse. Implemented:
`testRunCreatesNewGlobalResponseForSpecifiedApp()`
All PhpUnit and PhpStan tests are passing. This continues to address issue #9.


`tests\traits\TestsCreateApps` | `tests\command\NewGlobalResponseTest`:

Refactored `tests\traits\TestsCreateApps` to first check for `--for-app`
flag, and then `--name` when trying to determine App name.

Cleaned up code in tests\command\NewGlobalResponseTest
Also implemented new tests:

```
testRunSetsPositionTo_0_IfPositionIsNotSpecified()
testRunSetsPositionTo_0_IfPositionIsSpecifiedWithNoValue()
testRunThrowsRuntimeExceptionIfSpecifiedPositionIsNotNumeric()
```

`tests\command\NewGlobalResponseTest`: Code clean up. Implemented new test,
`testRunSetsPositionToSpecifiedPositionIfSpecifiedPositionIsNumeric()`, all
PhpUnit and PhpStan tests are passing.

`tests\command\NewGlobalResponseTest`: Implemented new test `testRunThrowsRuntimeExceptionIfGlobalResponseAlreadyExists()`,
all PhpUnit and PhpStan tests are passing. This continues to address issue #9.

helpFiles/help.txt: Updated help.txt

`ddms\classes\command\NewGlobalResponse`: `testRunThrowsRuntimeExpceptionIfSpecifiedNameIsNotAlphaNumeric()`.
All PhpUnit and PhpStan tests are passing.

`ddms\classes\command\NewGlobalResponse`: Finished initial implementation of
`ddms\classes\command\NewGlobalResponse`.

Implemented `testRunSetsNameToSpecifiedNameIfSpecifiedNameIsAlphaNumeric()`.
All PhpUnit and PhpStan tests are passing. This resolves issue #9.

