### PR TITLE
Ddms0.1.3 alpha | Implemented `ddms --new-request` | This resolves issue #10

### DIFF
--- a/FileTemplates/Request.php
+++ b/FileTemplates/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-/** APP_NAME | REQUEST_NAME.php */
+/** _NAME_.php */
 
 $appComponentsFactory->buildRequest(
     '_NAME_',

--- a/FileTemplates/Request.php
+++ b/FileTemplates/Request.php
@@ -3,7 +3,7 @@
 /** APP_NAME | REQUEST_NAME.php */
 
 $appComponentsFactory->buildRequest(
-    'REQUEST_NAME',
-    'REQUEST_CONTAINER',
-    $appComponentsFactory->getApp()->getAppDomain()->getUrl() . '/RELATIVE_URL',
+    '_NAME_',
+    '_CONTAINER_',
+    $appComponentsFactory->getApp()->getAppDomain()->getUrl() . '/_RELATIVE_URL_',
 );

--- a/ddms/classes/command/NewRequest.php
+++ b/ddms/classes/command/NewRequest.php
@@ -13,8 +13,7 @@ class NewRequest extends AbstractCommand implements Command
     public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
     {
         ['flags' => $flags] = $this->validateArguments($preparedArguments);
-        $template = strval(file_get_contents($this->pathToRequestTemplate()));
-        $content = str_replace(['_NAME_', '_CONTAINER_'], [$flags['name'][0], ($flags['container'][0] ?? 'Requests')], $template);
+        $content = $this->generateRequestConfigContent($flags);
         $userInterface->showMessage(
             PHP_EOL .
             'Creating new Request for App ' . $flags['for-app'][0] . ' at ' . $this->pathToNewRequest($flags) .
@@ -22,6 +21,15 @@ class NewRequest extends AbstractCommand implements Command
             PHP_EOL
         );
         return boolval(file_put_contents($this->pathToNewRequest($flags), $content));
+    }
+
+    /**
+     * @param array<string, array<int, string>> $flags
+     */
+    private function generateRequestConfigContent(array $flags): string
+    {
+        $template = strval(file_get_contents($this->pathToRequestTemplate()));
+        return str_replace(['_NAME_', '_CONTAINER_', '_RELATIVE_URL_'], [$flags['name'][0], ($flags['container'][0] ?? 'Requests'), ($flags['relative-url'] ?? 'index.php')], $template);
     }
 
     private function pathToRequestTemplate(): string

--- a/ddms/classes/command/NewRequest.php
+++ b/ddms/classes/command/NewRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace ddms\classes\command;
+
+use ddms\interfaces\command\Command;
+use ddms\abstractions\command\AbstractCommand;
+use ddms\interfaces\ui\UserInterface;
+use \RuntimeException;
+
+class NewRequest extends AbstractCommand implements Command
+{
+
+    public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool
+    {
+        ['flags' => $flags] = $this->validateArguments($preparedArguments);
+        $template = strval(file_get_contents($this->pathToRequestTemplate()));
+        $content = str_replace(['_NAME_', '_CONTAINER_'], [$flags['name'][0], ($flags['container'][0] ?? 'Requests')], $template);
+        $userInterface->showMessage(
+            PHP_EOL .
+            'Creating new Request for App ' . $flags['for-app'][0] . ' at ' . $this->pathToNewRequest($flags) .
+            PHP_EOL .
+            PHP_EOL
+        );
+        return boolval(file_put_contents($this->pathToNewRequest($flags), $content));
+    }
+
+    private function pathToRequestTemplate(): string
+    {
+        $templatePath = str_replace('ddms' . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'command', 'FileTemplates', __DIR__) . DIRECTORY_SEPARATOR . 'Request.php';
+        if(!file_exists($templatePath)) {
+            throw new RuntimeException('Error: The Request.php file template is missing! You will not be able to create new Requests until the Request.php template is restored at FileTemplates/Request.php');
+        }
+        return $templatePath;
+
+    }
+
+    /**
+     * @param array<string,array<int,string>> $flags
+     */
+    private function pathToNewRequest(array $flags): string
+    {
+        return $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['for-app'][0] . DIRECTORY_SEPARATOR . 'Requests' . DIRECTORY_SEPARATOR . $flags['name'][0] . '.php';
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     * @return array{"flags": array<string, array<int, string>>, "options": array<int, string>}
+     */
+    private function validateArguments(array $preparedArguments): array
+    {
+        ['flags' => $flags] = $preparedArguments;
+        if(!isset($flags['name'][0])) {
+            throw new RuntimeException('  Please specify a name for the new Request.');
+        }
+        if(!ctype_alnum($flags['name'][0])) {
+            throw new RuntimeException('  Please specify an alphanumeric name for the new Request.');
+        }
+        if(!isset($flags['for-app'][0])) {
+            throw new RuntimeException('  Please specify the name of the App to create the new Request for');
+        }
+        if(!file_exists($this->determineAppDirectoryPath($flags)) || !is_dir($this->determineAppDirectoryPath($flags))) {
+            throw new RuntimeException('  An App does not exist at' . $this->determineAppDirectoryPath($flags));
+        }
+        if(file_exists($this->pathToNewRequest($flags))) {
+            throw new RuntimeException('  Please specify a unique name for the new Request');
+        }
+        if(isset($flags['container'][0]) && !ctype_alnum($flags['container'][0])) {
+            throw new RuntimeException('  Please specify a numeric container for the new Request. For example `--container 1`.');
+        }
+        return $preparedArguments;
+    }
+
+    /**
+     * @param array <string, array<int, string>> $flags
+     */
+    private function determineAppDirectoryPath(array $flags): string
+    {
+        return  $flags['ddms-apps-directory-path'][0] . DIRECTORY_SEPARATOR . $flags['for-app'][0];
+    }
+
+
+}

--- a/ddms/classes/command/NewRequest.php
+++ b/ddms/classes/command/NewRequest.php
@@ -29,7 +29,7 @@ class NewRequest extends AbstractCommand implements Command
     private function generateRequestConfigContent(array $flags): string
     {
         $template = strval(file_get_contents($this->pathToRequestTemplate()));
-        return str_replace(['_NAME_', '_CONTAINER_', '_RELATIVE_URL_'], [$flags['name'][0], ($flags['container'][0] ?? 'Requests'), ($flags['relative-url'] ?? 'index.php')], $template);
+        return str_replace(['_NAME_', '_CONTAINER_', '_RELATIVE_URL_'], [$flags['name'][0], ($flags['container'][0] ?? 'Requests'), ($flags['relative-url'][0] ?? 'index.php')], $template);
     }
 
     private function pathToRequestTemplate(): string
@@ -75,7 +75,25 @@ class NewRequest extends AbstractCommand implements Command
         if(isset($flags['container'][0]) && !ctype_alnum($flags['container'][0])) {
             throw new RuntimeException('  Please specify a numeric container for the new Request. For example `--container 1`.');
         }
+        if(isset($flags['relative-url'][0])) {
+            $this->validateRelativeUrl($flags);
+        }
         return $preparedArguments;
+    }
+
+    /**
+     * @param array<string, array<int, string>> $flags
+     */
+    private function validateRelativeUrl(array $flags) : void
+    {
+        $tests = [
+            substr($flags['relative-url'][0], 0,5) !== 'http:',
+            substr($flags['relative-url'][0], 0,9) !== 'localhost',
+            filter_var('http://testdom.ain/' . $flags['relative-url'][0], FILTER_VALIDATE_URL) !== false,
+        ];
+        if(in_array(false, $tests, true)) {
+            throw new RuntimeException('  "' . $flags['relative-url'][0]  . '" is not a valid relative url. Please specify a valid relative url for the new Request. For example `index.php?foo=bar&baz=biz`.');
+        }
     }
 
     /**

--- a/tests/command/NewRequestTest.php
+++ b/tests/command/NewRequestTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace tests\command;
+
+use PHPUnit\Framework\TestCase;
+use ddms\classes\command\NewApp;
+use ddms\classes\command\NewRequest;
+use ddms\classes\ui\CommandLineUI;
+use ddms\interfaces\ui\UserInterface;
+use \RuntimeException;
+use tests\traits\TestsCreateApps;
+
+final class NewRequestTest extends TestCase
+{
+
+    use TestsCreateApps;
+
+    public function testRunThrowsRuntimeExceptionIf_name_IsNotSpecified(): void
+    {
+        $newRequest = new NewRequest();
+        $this->expectException(RuntimeException::class);
+        $newRequest->run(new CommandLineUI(), $newRequest->prepareArguments([]));
+    }
+
+    public function testRunThrowsRuntimeExceptionIf_for_app_IsNotSpecified(): void
+    {
+        $newRequest = new NewRequest();
+        $this->expectException(RuntimeException::class);
+        $newRequest->run(new CommandLineUI(), $newRequest->prepareArguments(['--name', 'Foo']));
+    }
+
+    public function testRunThrowsRuntimeExceptionIfSpecifiedAppDoesNotExist(): void
+    {
+        $newRequest = new NewRequest();
+        $this->expectException(RuntimeException::class);
+        $newRequest->run(new CommandLineUI(), $newRequest->prepareArguments(['--name', 'Foo', '--for-app', 'Baz' . strval(rand(10000,9999))]));
+    }
+
+    public function testRunCreatesNewRequestForSpecifiedApp(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $responseName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $responseName, '--for-app', $appName]);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->assertTrue(file_exists($this->expectedRequestPath($preparedArguments)));
+    }
+
+    public function testRunThrowsRuntimeExceptionIfRequestAlreadyExists(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $responseName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $responseName, '--for-app', $appName]);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->expectException(RuntimeException::class);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunThrowsRuntimeExpceptionIfSpecifiedNameIsNotAlphaNumeric(): void
+    {
+        #ctype_alnum($string)
+        $appName = $this->createTestAppReturnName();
+        $responseName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $responseName . '!@#$%^&*()_+=-\][\';"\\,.', '--for-app', $appName]);
+        $this->expectException(RuntimeException::class);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunSetsNameToSpecifiedNameIfSpecifiedNameIsAlphaNumeric(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $responseName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $responseName, '--for-app', $appName]);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), file_get_contents($this->expectedRequestPath($preparedArguments)));
+    }
+
+    public function testRunSetsContainerTo_Requests_IfContainerIsNotSpecified(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $requestName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $requestName, '--for-app', $appName]);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), $this->getNewRequestContent($preparedArguments));
+    }
+
+    public function testRunSetsContainerTo_Requests_IfContainerIsSpecifiedWithNoValue(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $requestName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $requestName, '--for-app', $appName, '--container']);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), file_get_contents($this->expectedRequestPath($preparedArguments)));
+    }
+
+    public function testRunThrowsRuntimeExceptionIfSpecifiedContainerIsNotAlphaNumeric(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $requestName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $this->expectException(RuntimeException::class);
+        $newRequest->run(new CommandLineUI(), $newRequest->prepareArguments(['--name', $requestName, '--for-app', $appName, '--container', 'FooBarBaz*#$%*']));
+    }
+
+    public function testRunSetsContainerToSpecifiedContainerIfSpecifiedContainerIsAlphaNumeric(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $requestName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $requestName, '--for-app', $appName, '--container', 'ValidContainerName']);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), file_get_contents($this->expectedRequestPath($preparedArguments)));
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function getNewRequestContent($preparedArguments): string
+    {
+        return strval(file_get_contents($this->expectedRequestPath($preparedArguments)));
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function expectedRequestPath(array $preparedArguments): string
+    {
+        return self::expectedAppDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Requests' . DIRECTORY_SEPARATOR . $preparedArguments['flags']['name'][0] . '.php';
+    }
+
+    private function createTestAppReturnName(): string
+    {
+        $appName = self::getRandomAppName();
+        $newApp = new NewApp();
+        $newAppPreparedArguments = $newApp->prepareArguments(['--name', $appName]);
+        $newApp->run(new CommandLineUI(), $newAppPreparedArguments);
+        return $appName;
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function determineExpectedRequestPhpContent(array $preparedArguments): string
+    {
+        return str_replace(
+            [
+                '_NAME_',
+                '_CONTAINER_'
+            ],
+            [
+                $preparedArguments['flags']['name'][0],
+                ($preparedArguments['flags']['container'][0] ?? 'Requests')
+            ],
+            strval(file_get_contents($this->expectedTemplateFilePath()))
+        );
+    }
+
+    private function expectedTemplateFilePath(): string
+    {
+        return str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'FileTemplates', __DIR__) . DIRECTORY_SEPARATOR . 'Request.php';
+    }
+
+}

--- a/tests/command/NewRequestTest.php
+++ b/tests/command/NewRequestTest.php
@@ -117,6 +117,16 @@ final class NewRequestTest extends TestCase
         $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), file_get_contents($this->expectedRequestPath($preparedArguments)));
     }
 
+    public function testRunSetsRelativeUrlTo_index_php_IfRelativeUrlIsNotSpecified(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $requestName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $requestName, '--for-app', $appName]);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), $this->getNewRequestContent($preparedArguments));
+    }
+
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */
@@ -150,11 +160,13 @@ final class NewRequestTest extends TestCase
         return str_replace(
             [
                 '_NAME_',
-                '_CONTAINER_'
+                '_CONTAINER_',
+                '_RELATIVE_URL_'
             ],
             [
                 $preparedArguments['flags']['name'][0],
-                ($preparedArguments['flags']['container'][0] ?? 'Requests')
+                ($preparedArguments['flags']['container'][0] ?? 'Requests'),
+                ($preparedArguments['flags']['relative-url'][0] ?? 'index.php')
             ],
             strval(file_get_contents($this->expectedTemplateFilePath()))
         );

--- a/tests/command/NewRequestTest.php
+++ b/tests/command/NewRequestTest.php
@@ -127,6 +127,35 @@ final class NewRequestTest extends TestCase
         $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), $this->getNewRequestContent($preparedArguments));
     }
 
+    public function testRunThrowsRuntimeExceptionIfRelativeUrlIsNotValid(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $requestName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $this->expectException(RuntimeException::class);
+        $newRequest->run(new CommandLineUI(), $newRequest->prepareArguments(['--name', $requestName, '--for-app', $appName, '--relative-url', $this->getRandomInvalidRelativeUrl()]));
+    }
+
+    public function testRunSetsRelativeUrlToSpecifiedRelativeUrlIfSpecifiedRelativeUrlIsValid(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $requestName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $requestName, '--for-app', $appName, '--relative-url', 'index.php?foo=bar&baz=biz']);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), file_get_contents($this->expectedRequestPath($preparedArguments)));
+    }
+
+    private function getRandomInvalidRelativeUrl(): string
+    {
+        $invalidUrls = [
+            'http://localhost:' . strval(rand(8000, 8999)) . '/index.php',
+            'localhost:' . strval(rand(8000, 8999)) . '/index.php',
+            'localhost/index.php',
+        ];
+        return $invalidUrls[array_rand($invalidUrls)];
+    }
+
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */

--- a/tests/command/NewRequestTest.php
+++ b/tests/command/NewRequestTest.php
@@ -127,6 +127,16 @@ final class NewRequestTest extends TestCase
         $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), $this->getNewRequestContent($preparedArguments));
     }
 
+    public function testRunSetsRelativeUrlTo_index_php_IfRelativeUrlIsSpecifiedWithNoValue(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $requestName = $appName . 'Request';
+        $newRequest = new NewRequest();
+        $preparedArguments = $newRequest->prepareArguments(['--name', $requestName, '--for-app', $appName, '--relative-url']);
+        $newRequest->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), file_get_contents($this->expectedRequestPath($preparedArguments)));
+    }
+
     public function testRunThrowsRuntimeExceptionIfRelativeUrlIsNotValid(): void
     {
         $appName = $this->createTestAppReturnName();


### PR DESCRIPTION
### Ddms0.1.3 alpha | Implemented `ddms --new-request` | This resolves issue #10

`ddms\classes\command\NewRequest`: Began development of `ddms\classes\command\NewRequest`. Implemented the following tests:
```

     testRunThrowsRuntimeExceptionIf_name_IsNotSpecified()
     testRunThrowsRuntimeExceptionIf_for_app_IsNotSpecified()
     testRunThrowsRuntimeExceptionIfSpecifiedAppDoesNotExist()
     testRunCreatesNewRequestForSpecifiedApp()
     testRunThrowsRuntimeExceptionIfRequestAlreadyExists()
     testRunThrowsRuntimeExpceptionIfSpecifiedNameIsNotAlphaNumeric()
     testRunSetsNameToSpecifiedNameIfSpecifiedNameIsAlphaNumeric()
     testRunSetsContainerTo_Requests_IfContainerIsNotSpecified()
     testRunSetsContainerTo_Requests_IfContainerIsSpecifiedWithNoValue()
     testRunThrowsRuntimeExceptionIfSpecifiedContainerIsNotAlphaNumeric()
     testRunSetsContainerToSpecifiedContainerIfSpecifiedContainerIsAlphaNumeric()

```

`ddms\classes\command\NewRequest`: Implemented new test, `testRunSetsRelativeUrlTo_index_php_IfRelativeUrlIsNotSpecified()`. 

`ddms\classes\command\NewRequest`: Implemented new tests: `testRunThrowsRuntimeExceptionIfRelativeUrlIsNotValid(), testRunSetsRelativeUrlToSpecifiedRelativeUrlIfSpecifiedRelativeUrlIsValid()`. 

`ddms\classes\command\NewRequest`: Implemented new tests: `testRunSetsRelativeUrlTo_index_php_IfRelativeUrlIsSpecifiedWithNoValue()`

FileTemplates: Revised FileTemplates/Request.php

All PhpUnit and PhpStan tests are passing. 

This resolves issue #10 
