### PR TITLE
Ddms0.0.1 beta

### DIFF
--- a/ddms/classes/command/NewDynamicOutputComponent.php
+++ b/ddms/classes/command/NewDynamicOutputComponent.php
@@ -173,6 +173,9 @@ class NewDynamicOutputComponent extends AbstractCommand implements Command
         if(isset($flags['initial-output-file'][0]) && file_exists($this->pathToNewDynamicOutputFile($flags))) {
             throw new RuntimeException($this->dynamicOutputFileExistsMessage($flags));
         }
+        if(isset($flags['initial-output-file'][0]) && !file_exists($flags['initial-output-file'][0])) {
+            throw new RuntimeException('  The specified --initial-output-file does not exist at ' . $flags['initial-output-file'][0] . ' Please specify an existing --initial-output-file');
+        }
         return $preparedArguments;
     }
 

--- a/ddms/classes/command/NewDynamicOutputComponent.php
+++ b/ddms/classes/command/NewDynamicOutputComponent.php
@@ -111,9 +111,17 @@ class NewDynamicOutputComponent extends AbstractCommand implements Command
     {
         return (
             isset($flags['shared'])
-            ? $this->determineSharedDynamicOutputDirectoryPath($flags) . DIRECTORY_SEPARATOR . ($flags['file-name'][0] ?? $flags['name'][0] . '.php')
-            : $this->determineAppsDynamicOutputDirectoryPath($flags) . DIRECTORY_SEPARATOR . ($flags['file-name'][0] ?? $flags['name'][0] . '.php')
+            ? $this->determineSharedDynamicOutputDirectoryPath($flags) . DIRECTORY_SEPARATOR . $this->determineDynamicOutputFileName($flags)
+            : $this->determineAppsDynamicOutputDirectoryPath($flags) . DIRECTORY_SEPARATOR . $this->determineDynamicOutputFileName($flags)
         );
+    }
+
+    /**
+     * @param array<string,array<int,string>> $flags
+     */
+    private function determineDynamicOutputFileName(array $flags) : string
+    {
+        return ($flags['file-name'][0] ?? $flags['name'][0] . '.php');
     }
 
     /**
@@ -159,7 +167,21 @@ class NewDynamicOutputComponent extends AbstractCommand implements Command
         if(isset($flags['position'][0]) && !is_numeric($flags['position'][0])) {
             throw new RuntimeException('  Please specify a numeric position for the new DynamicOutputComponent. For example `--position 1`.');
         }
+        if(isset($flags['initial-output'][0]) && file_exists($this->pathToNewDynamicOutputFile($flags))) {
+            throw new RuntimeException($this->dynamicOutputFileExistsMessage($flags));
+        }
+        if(isset($flags['initial-output-file'][0]) && file_exists($this->pathToNewDynamicOutputFile($flags))) {
+            throw new RuntimeException($this->dynamicOutputFileExistsMessage($flags));
+        }
         return $preparedArguments;
+    }
+
+    /**
+     * @param array<string,array<int,string>> $flags
+     */
+    private function dynamicOutputFileExistsMessage(array $flags): string
+    {
+        return '  A dynamic output file named ' . $this->determineDynamicOutputFileName($flags) . ' already exists, please use the --file-name flag to specify a unique file name for the new dynamic output file that will be created for the new DynamicOutputComponent.';
     }
 
 }

--- a/tests/command/NewDynamicOutputComponentTest.php
+++ b/tests/command/NewDynamicOutputComponentTest.php
@@ -403,4 +403,18 @@ testRunDoesNotCreateDynamicOutputFileInSharedDynamicOutputDirectoryIfSharedFlagI
         $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
     }
 
+    public function testRunThrowsRuntimeExpceptionIfSpecified_initial_output_file_DoesNotExist(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $arguments = [
+            '--name', 'FirstDynamicOutputComponent',
+            '--file-name', 'dynamicOutputFile.txt',
+            '--for-app', $appName,
+            '--initial-output-file', 'Foo' . strval(rand(420, 4200))
+        ];
+        $newDynamicOutputComponent = new NewDynamicOutputComponent();
+        $preparedArguments = $newDynamicOutputComponent->prepareArguments($arguments);
+        $this->expectException(RuntimeException::class);
+        $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
+    }
 }

--- a/tests/command/NewDynamicOutputComponentTest.php
+++ b/tests/command/NewDynamicOutputComponentTest.php
@@ -365,4 +365,42 @@ testRunDoesNotCreateDynamicOutputFileInSharedDynamicOutputDirectoryIfSharedFlagI
         return str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'FileTemplates', __DIR__) . DIRECTORY_SEPARATOR . 'DynamicOutputComponent.php';
     }
 
+################
+
+    public function testRunThrowsRuntimeExpceptionIf_initial_output_FlagIsSpecifiedAndCreationOfNewDynamicOutputFileWouldOverwriteAnExistingDynamicOutputFile(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $arguments = [
+            '--name', 'FirstDynamicOutputComponent',
+            '--file-name', 'dynamicOutputFile.txt',
+            '--for-app', $appName,
+            '--initial-output', 'Foo bar baz'
+        ];
+        $newDynamicOutputComponent = new NewDynamicOutputComponent();
+        $preparedArguments = $newDynamicOutputComponent->prepareArguments($arguments);
+        $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
+        $arguments['--name'] = 'SecondDynamicOutputComponent';
+        $preparedArguments = $newDynamicOutputComponent->prepareArguments($arguments);
+        $this->expectException(RuntimeException::class);
+        $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunThrowsRuntimeExpceptionIf_initial_output_file_FlagIsSpecifiedAndCreationOfNewDynamicOutputFileWouldOverwriteAnExistingDynamicOutputFile(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $arguments = [
+            '--name', 'FirstDynamicOutputComponent',
+            '--file-name', 'dynamicOutputFile.txt',
+            '--for-app', $appName,
+            '--initial-output-file', __FILE__
+        ];
+        $newDynamicOutputComponent = new NewDynamicOutputComponent();
+        $preparedArguments = $newDynamicOutputComponent->prepareArguments($arguments);
+        $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
+        $arguments['--name'] = 'SecondDynamicOutputComponent';
+        $preparedArguments = $newDynamicOutputComponent->prepareArguments($arguments);
+        $this->expectException(RuntimeException::class);
+        $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
+    }
+
 }


### PR DESCRIPTION
`ddms\classes\command\NewDynamicOutputComponent`: 

Began addressing issue #26 and issue #27. Began implementing `ddms --new-dynamic-output-component ... --initial-output` and `ddms --new-dynamic-output-component ... --initial-output-file`. 

Implemented the following tests:

```
testRunThrowsRuntimeExpceptionIf_initial_output_FlagIsSpecifiedAndCreationOfNewDynamicOutputFileWouldOverwriteAnExistingDynamicOutputFile() 

testRunThrowsRuntimeExpceptionIf_initial_output_file_FlagIsSpecifiedAndCreationOfNewDynamicOutputFileWouldOverwriteAnExistingDynamicOutputFile()

testRunThrowsRuntimeExpceptionIfSpecified_initial_output_file_DoesNotExist()

```

All PhpUnit and PhpStan tests are passing.

