### PR TITLE
Ddms0.0.1 beta dev

### DIFF
--- a/ddms/classes/command/NewDynamicOutputComponent.php
+++ b/ddms/classes/command/NewDynamicOutputComponent.php
@@ -60,7 +60,7 @@ class NewDynamicOutputComponent extends AbstractCommand implements Command
         if(isset($flags['initial-output-file'][0]) && file_exists($flags['initial-output-file'][0])) {
             return strval(file_get_contents($flags['initial-output-file'][0]));
         }
-        return ($flags['initial-output'][0] ?? '');
+        return (!empty($flags['initial-output']) ? implode(' ', $flags['initial-output']) : '');
     }
 
     private function showMessage(string $message) : void

--- a/ddms/classes/command/NewDynamicOutputComponent.php
+++ b/ddms/classes/command/NewDynamicOutputComponent.php
@@ -43,13 +43,24 @@ class NewDynamicOutputComponent extends AbstractCommand implements Command
             }
             file_put_contents(
                 $this->pathToNewDynamicOutputFile($flags),
-                ($flags['initial-output'][0] ?? '')
+                $this->determineInitialDynamicOutputFileContent($flags)
             );
             $this->showMessage(
                 'Creating dynamic output file for new DynamicOutputComponent at ' .
                 $this->pathToNewDynamicOutputFile($flags)
             );
         }
+    }
+
+    /**
+     * @param array<string, array<int, string>> $flags
+     */
+    private function determineInitialDynamicOutputFileContent(array $flags): string
+    {
+        if(isset($flags['initial-output-file'][0]) && file_exists($flags['initial-output-file'][0])) {
+            return strval(file_get_contents($flags['initial-output-file'][0]));
+        }
+        return ($flags['initial-output'][0] ?? '');
     }
 
     private function showMessage(string $message) : void

--- a/ddms/classes/command/NewDynamicOutputComponent.php
+++ b/ddms/classes/command/NewDynamicOutputComponent.php
@@ -43,7 +43,7 @@ class NewDynamicOutputComponent extends AbstractCommand implements Command
             }
             file_put_contents(
                 $this->pathToNewDynamicOutputFile($flags),
-                ''
+                ($flags['initial-output'][0] ?? '')
             );
             $this->showMessage(
                 'Creating dynamic output file for new DynamicOutputComponent at ' .

--- a/ddms/classes/command/NewDynamicOutputComponent.php
+++ b/ddms/classes/command/NewDynamicOutputComponent.php
@@ -176,6 +176,9 @@ class NewDynamicOutputComponent extends AbstractCommand implements Command
         if(isset($flags['initial-output-file'][0]) && !file_exists($flags['initial-output-file'][0])) {
             throw new RuntimeException('  The specified --initial-output-file does not exist at ' . $flags['initial-output-file'][0] . ' Please specify an existing --initial-output-file');
         }
+        if(isset($flags['initial-output'][0]) && isset($flags['initial-output-file'][0])) {
+            throw new RuntimeException('  The --initial-output and --initial-output-file flags cannot be used together.  For help use ddms --help --new-dynamic-output-file');
+        }
         return $preparedArguments;
     }
 

--- a/tests/command/NewDynamicOutputComponentTest.php
+++ b/tests/command/NewDynamicOutputComponentTest.php
@@ -417,4 +417,20 @@ testRunDoesNotCreateDynamicOutputFileInSharedDynamicOutputDirectoryIfSharedFlagI
         $this->expectException(RuntimeException::class);
         $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
     }
+
+    public function testRunThrowsRuntimeExpceptionIfBoth_initial_output_And_initial_output_file_FlagsAreSpecified(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $arguments = [
+            '--name', $appName . 'DynamicOutputComponent',
+            '--for-app', $appName,
+            '--initial-output', 'Foo bar baz',
+            '--initial-output-file', __FILE__
+        ];
+        $newDynamicOutputComponent = new NewDynamicOutputComponent();
+        $preparedArguments = $newDynamicOutputComponent->prepareArguments($arguments);
+        $this->expectException(RuntimeException::class);
+        $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
+    }
 }
+

--- a/tests/command/NewDynamicOutputComponentTest.php
+++ b/tests/command/NewDynamicOutputComponentTest.php
@@ -433,7 +433,7 @@ testRunDoesNotCreateDynamicOutputFileInSharedDynamicOutputDirectoryIfSharedFlagI
         $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
     }
 
-    public function testRunDynamicOutputFilesContentToSpecifiedInitialOutputIf_initial_output_FlagIsSpecified(): void
+    public function testRunSetDynamicOutputFilesContentToSpecifiedInitialOutputIf_initial_output_FlagIsSpecified(): void
     {
         $appName = $this->createTestAppReturnName();
         $initialOutput = 'Foo bar ' . strval(rand(420, 4200));

--- a/tests/command/NewDynamicOutputComponentTest.php
+++ b/tests/command/NewDynamicOutputComponentTest.php
@@ -442,7 +442,28 @@ testRunDoesNotCreateDynamicOutputFileInSharedDynamicOutputDirectoryIfSharedFlagI
         $newDynamicOutputComponent = new NewDynamicOutputComponent();
         $preparedArguments = $newDynamicOutputComponent->prepareArguments(['--name', $dynamicOutputComponentName, '--for-app', $appName, '--initial-output', $initialOutput, '--file-name', $fileName]);
         $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
-        $this->assertEquals($initialOutput, strval(file_get_contents($this->determineDynamicOutputFilePath($fileName, $preparedArguments))));
+        $this->assertEquals($initialOutput, $this->getDynamicOutputFileContents($fileName, $preparedArguments));
+    }
+
+    public function testRunSetDynamicOutputFilesContentToMatchSpecifiedFilesContentIf_initial_output_file_FlagIsSpecified(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $expectedOutputFilePath = __FILE__;
+        $expectedOutput = strval(file_get_contents($expectedOutputFilePath));
+        $dynamicOutputComponentName = $appName . 'DynamicOutputComponent';
+        $fileName = $dynamicOutputComponentName . '.php';
+        $newDynamicOutputComponent = new NewDynamicOutputComponent();
+        $preparedArguments = $newDynamicOutputComponent->prepareArguments(['--name', $dynamicOutputComponentName, '--for-app', $appName, '--initial-output-file', $expectedOutputFilePath]);
+        $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($expectedOutput, $this->getDynamicOutputFileContents($fileName, $preparedArguments));
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function getDynamicOutputFileContents(string $fileName, array $preparedArguments): string
+    {
+        return strval(file_get_contents($this->determineDynamicOutputFilePath($fileName, $preparedArguments)));
     }
 
     /**

--- a/tests/command/NewDynamicOutputComponentTest.php
+++ b/tests/command/NewDynamicOutputComponentTest.php
@@ -432,5 +432,30 @@ testRunDoesNotCreateDynamicOutputFileInSharedDynamicOutputDirectoryIfSharedFlagI
         $this->expectException(RuntimeException::class);
         $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
     }
+
+    public function testRunDynamicOutputFilesContentToSpecifiedInitialOutputIf_initial_output_FlagIsSpecified(): void
+    {
+        $appName = $this->createTestAppReturnName();
+        $initialOutput = 'Foo bar ' . strval(rand(420, 4200));
+        $dynamicOutputComponentName = $appName . 'DynamicOutputComponent';
+        $fileName = $dynamicOutputComponentName . '.html';
+        $newDynamicOutputComponent = new NewDynamicOutputComponent();
+        $preparedArguments = $newDynamicOutputComponent->prepareArguments(['--name', $dynamicOutputComponentName, '--for-app', $appName, '--initial-output', $initialOutput, '--file-name', $fileName]);
+        $newDynamicOutputComponent->run(new CommandLineUI(), $preparedArguments);
+        $this->assertEquals($initialOutput, strval(file_get_contents($this->determineDynamicOutputFilePath($fileName, $preparedArguments))));
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function determineDynamicOutputFilePath(string $fileName, array $preparedArguments): string
+    {
+        $dynamicOutputFilePath = $this->expectedAppDynamicOutputDirectoryPath($preparedArguments) . DIRECTORY_SEPARATOR . $fileName;
+        if(!file_exists($dynamicOutputFilePath)) {
+            throw new RuntimeException('  NewDynamicOutputComponentTest Error: A dynamic output file does not exist at the expected path: ' . $dynamicOutputFilePath);
+        }
+        return $dynamicOutputFilePath;
+    }
+
 }
 


### PR DESCRIPTION
`ddms\classes\command\NewDynamicOutputComponent`: 

Continued addressing issue #26 and issue #27. 

Implemented the following tests:
```

testRunThrowsRuntimeExpceptionIfBoth_initial_output_And_initial_output_file_FlagsAreSpecified()

testRunSetDynamicOutputFilesContentToSpecifiedInitialOutputIf_initial_output_FlagIsSpecified()

testRunSetDynamicOutputFilesContentToMatchSpecifiedFilesContentIf_initial_output_file_FlagIsSpecified()
```

All PhpUnit and PhpStan tests are passing.

`ddms\classes\command\NewDynamicOutputComponent`: Refactored to insure all arguments passed to `--initial-output` are included in the initial content of the new dynamic output file created for the new `DynamicOutputComponent`. 

This merge resolves issue # 26 and issue #27.