### PR TITLE
Ddms0.0.3 beta

### DIFF
--- a/ddms/classes/command/MakeAppPackage.php
+++ b/ddms/classes/command/MakeAppPackage.php
@@ -19,14 +19,28 @@ class MakeAppPackage extends AbstractCommand implements Command
         $this->validateArguments($preparedArguments);
         $this->validateAppPackagesMakeSh($preparedArguments);
         $this->makeAppPackage($preparedArguments);
+        $this->showMessage(
+            '  Successfully made App Package at ' .
+            $preparedArguments['flags']['path'][0] .
+            ' into an App at ' .
+            $preparedArguments['flags']['ddms-apps-directory-path'][0] .
+            DIRECTORY_SEPARATOR . $this->determineAppName($preparedArguments)
+        );
         return true;
+    }
+
+    private function showMessage(string $message): void
+    {
+        $this->currentUserInterface->showMessage(
+            PHP_EOL . $message . PHP_EOL . PHP_EOL
+        );
     }
 
     /**
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */
     private function makeAppPackage(array $preparedArguments): void {
-        exec($this->determineMakeShPath($preparedArguments));
+        $this->showMessage(strval(shell_exec($this->determineMakeShPath($preparedArguments))));
     }
 
     /**

--- a/ddms/classes/command/MakeAppPackage.php
+++ b/ddms/classes/command/MakeAppPackage.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace ddms\classes\command;
+
+use ddms\interfaces\command\Command;
+use ddms\abstractions\command\AbstractCommand;
+use ddms\interfaces\ui\UserInterface;
+use \RuntimeException;
+
+class MakeAppPackage extends AbstractCommand implements Command
+{
+    /**
+     * @var UserInterface $currentUserInterface
+     */
+    private $currentUserInterface;
+
+    public function run(UserInterface $userInterface, array $preparedArguments = ['flags' => [], 'options' => []]): bool {
+        $this->currentUserInterface = $userInterface;
+        $this->validateArguments($preparedArguments);
+        $this->validateAppPackagesMakeSh($preparedArguments);
+        return true;
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function validateArguments(array $preparedArguments): void
+    {
+        if(!isset($preparedArguments['flags']['path'][0])) {
+            throw new RuntimeException('  Please specify the path to the App Package to make.' . PHP_EOL);
+        }
+        if(!file_exists($preparedArguments['flags']['path'][0])) {
+            throw new RuntimeException('  Please specify a path to an existing App Package.' . PHP_EOL);
+        }
+        if(!file_exists($preparedArguments['flags']['path'][0] . DIRECTORY_SEPARATOR . 'make.sh')) {
+            throw new RuntimeException('  Please specify a path to an actual App Package.' . PHP_EOL);
+        }
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function validateAppPackagesMakeSh(array $preparedArguments): void
+    {
+        $this->validateMakeShCallsToDdmsNewApp($preparedArguments);
+        $this->validateMakeShIsExecutable($preparedArguments);
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function validateMakeShCallsToDdmsNewApp(array $preparedArguments): void
+    {
+        $makeShContent = strval(file_get_contents($this->determineMakeShPath($preparedArguments)));
+        $callsToDdmsNewApp = substr_count($makeShContent, 'ddms --new-app');
+        if($callsToDdmsNewApp !== 1) {
+            switch($callsToDdmsNewApp < 1) {
+                case true:
+                    throw new RuntimeException(
+                        '  The specified App Package\'s make.sh is not valid' . PHP_EOL .
+                        '  because it does not define a call to `ddms --new-app`.' . PHP_EOL . PHP_EOL .
+                        '  An App Package\'s make.sh MUST define exactly one call to `ddms --new-app`.' . PHP_EOL .
+                        '  App Packages MUST create an App, and MUST NOT create more than one App.' . PHP_EOL
+                    );
+                default:
+                    throw new RuntimeException(
+                        '  The specified App Package\'s make.sh is not valid' . PHP_EOL .
+                        '  because it defines more than one call to `ddms --new-app`.' . PHP_EOL . PHP_EOL .
+                        '  An App Package\'s make.sh MUST define exactly one call to `ddms --new-app`.' . PHP_EOL .
+                        '  App Packages MUST create an App, and MUST NOT create more than one App.' . PHP_EOL
+                    );
+            }
+        }
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function validateMakeShIsExecutable(array $preparedArguments): void
+    {
+        if(substr(sprintf('%o', fileperms('/home/darling/Downloads/vendor/darling/ddms/testAppPackages/ddmsTestAppPackageInValidMakeShNotExecutable/make.sh')), -4, 2) < 6) {
+           throw new RuntimeException('    Make sh not exec');
+        }
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function determineMakeShPath($preparedArguments): string
+    {
+        return $preparedArguments['flags']['path'][0] . DIRECTORY_SEPARATOR . 'make.sh';
+    }
+
+}
+
+

--- a/testAppPackages/ddmsTestAppPackageInValidMakeShMultiCallNewApp/make.sh
+++ b/testAppPackages/ddmsTestAppPackageInValidMakeShMultiCallNewApp/make.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# make.sh
+# NOTE: This App Package is specifically designed for use by the tests defined for
+#       `ddms --make-app-package`. DO NOT USE THIS APP PACKAGE FOR ANYTHING ELSE!
+set -o posix
+
+ddms --new-app --name Foo
+
+ddms --new-app --name Bar
+

--- a/testAppPackages/ddmsTestAppPackageInValidMakeShNotExecutable/make.sh
+++ b/testAppPackages/ddmsTestAppPackageInValidMakeShNotExecutable/make.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# make.sh
+# NOTE: This App Package is specifically designed for use by the tests defined for
+#       `ddms --make-app-package`. DO NOT USE THIS APP PACKAGE FOR ANYTHING ELSE!
+
+set -o posix
+
+/home/darling/Downloads/vendor/darling/ddms/bin/ddms --new-app --name ddmsTestAppPackageValidMakeSh --domain "http://localhost:8080/" --debug flags options
+

--- a/testAppPackages/ddmsTestAppPackageInValidMakeShSingleCallNewApp/make.sh
+++ b/testAppPackages/ddmsTestAppPackageInValidMakeShSingleCallNewApp/make.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# make.sh
+# NOTE: This App Package is specifically designed for use by the tests defined for
+#       `ddms --make-app-package`. DO NOT USE THIS APP PACKAGE FOR ANYTHING ELSE!
+set -o posix
+
+

--- a/testAppPackages/ddmsTestAppPackageInValidMakeShWrongName/make.sh
+++ b/testAppPackages/ddmsTestAppPackageInValidMakeShWrongName/make.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# make.sh
+# NOTE: This App Package is specifically designed for use by the tests defined for
+#       `ddms --make-app-package`. DO NOT USE THIS APP PACKAGE FOR ANYTHING ELSE!
+
+set -o posix
+
+/home/darling/Downloads/vendor/darling/ddms/bin/ddms --new-app --name WrongName --domain "http://localhost:8080/" --debug flags options
+

--- a/testAppPackages/ddmsTestAppPackageValidMakeSh/make.sh
+++ b/testAppPackages/ddmsTestAppPackageValidMakeSh/make.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# make.sh
+# NOTE: This App Package is specifically designed for use by the tests defined for
+#       `ddms --make-app-package`. DO NOT USE THIS APP PACKAGE FOR ANYTHING ELSE!
+
+set -o posix
+
+/home/darling/Downloads/vendor/darling/ddms/bin/ddms --new-app --name ddmsTestAppPackageValidMakeSh --domain "http://localhost:8080/" --debug flags options
+

--- a/tests/command/MakeAppPackageTest.php
+++ b/tests/command/MakeAppPackageTest.php
@@ -74,7 +74,7 @@ final class MakeAppPackageTest extends TestCase
         $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
     }
 
-    public function testRunThrowsRuntimeExceptionIfSpecifiedPathIncludesA_make_sh_WhoseCallToDdmsNewAppUsesWrongName(): void
+    public function testRunThrowsRuntimeExceptionIfSpecifiedPathIncludesA_make_sh_WhoseCallToDdmsNewAppUsesANameThatDoesNotMatchTheAppPackagesName(): void
     {
         $makeAppPackage = new MakeAppPackage();
         $preparedArguments = $makeAppPackage->prepareArguments(

--- a/tests/command/MakeAppPackageTest.php
+++ b/tests/command/MakeAppPackageTest.php
@@ -54,7 +54,7 @@ final class MakeAppPackageTest extends TestCase
         $preparedArguments = $makeAppPackage->prepareArguments(
             [
                 '--path',
-                $this->pathToInValidAppPackage()
+                $this->pathToInvalidAppPackage_InvalidNumberOfCallsToDdmsNewApp()
             ]
         );
         $this->expectException(RuntimeException::class);
@@ -74,6 +74,90 @@ final class MakeAppPackageTest extends TestCase
         $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
     }
 
+    public function testRunThrowsRuntimeExceptionIfSpecifiedPathIncludesA_make_sh_WhoseCallToDdmsNewAppUsesWrongName(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        $preparedArguments = $makeAppPackage->prepareArguments(
+            [
+                '--path',
+                $this->pathToAppPackageWhoseMakeShCallToDdmsNewAppUsesWrongName()
+            ]
+        );
+        $this->expectException(RuntimeException::class);
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunThrowsRuntimeExceptionIfAppWasAlreadyMade(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        $this->registerAppName(strval(basename($this->pathToValidAppPackage())));
+        $preparedArguments = $makeAppPackage->prepareArguments(
+            [
+                '--path',
+                $this->pathToValidAppPackage()
+            ]
+        );
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+        $this->expectException(RuntimeException::class);
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunResultsInANewAppWithExpectedFilesAndDirectoriesPresent(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        $preparedArguments = $makeAppPackage->prepareArguments(
+            [
+                '--path',
+                $this->pathToValidAppPackage()
+            ]
+        );
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+        $this->assertTrue(
+            file_exists($this->expectedNewAppPath($preparedArguments)),
+            'ddms --make-app-package MUST make an App when run, a new App should have been created at ' . $this->expectedNewAppPath($preparedArguments)
+        );
+        $this->assertTrue(
+            file_exists($this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php'),
+            'ddms --make-app-package MUST make an App when run, a Components.php file should have been created for the new App at ' . $this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'Components.php'
+        );
+        $this->assertTrue(
+            file_exists($this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'css'),
+            'ddms --make-app-package MUST make an App when run, a css directory should have been created for the new App at ' . $this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'css'
+        );
+        $this->assertTrue(
+            file_exists($this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'js'),
+            'ddms --make-app-package MUST make an App when run, a js directory should have been created for the new App at ' . $this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'js'
+        );
+        $this->assertTrue(
+            file_exists($this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'resources'),
+            'ddms --make-app-package MUST make an App when run, a resources directory should have been created for the new App at ' . $this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'resources'
+        );
+        $this->assertTrue(
+            file_exists($this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'DynamicOutput'),
+            'ddms --make-app-package MUST make an App when run, a DynamicOutput directory should have been created for the new App at ' . $this->expectedNewAppPath($preparedArguments) . DIRECTORY_SEPARATOR . 'DynamicOutput'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        foreach(self::$createdApps as $appName) {
+            $preparedArguments = $makeAppPackage->prepareArguments(['--name', $appName]);
+            self::removeDirectory(self::expectedAppDirectoryPath($preparedArguments));
+        }
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function expectedNewAppPath(array $preparedArguments): string {
+        $name = strval(basename($preparedArguments['flags']['path'][0]));
+        return strval(
+            realpath($preparedArguments['flags']['ddms-apps-directory-path'][0])
+        ) .
+        DIRECTORY_SEPARATOR . $name;
+    }
+
     private function pathToValidAppPackage(): string
     {
         return strval(
@@ -81,6 +165,19 @@ final class MakeAppPackageTest extends TestCase
                 str_replace(
                     'tests' . DIRECTORY_SEPARATOR . 'command',
                     'testAppPackages' . DIRECTORY_SEPARATOR . 'ddmsTestAppPackageValidMakeSh',
+                    __DIR__
+                )
+            )
+        );
+    }
+
+    private function pathToAppPackageWhoseMakeShCallToDdmsNewAppUsesWrongName(): string
+    {
+        return strval(
+            realpath(
+                str_replace(
+                    'tests' . DIRECTORY_SEPARATOR . 'command',
+                    'testAppPackages' . DIRECTORY_SEPARATOR . 'ddmsTestAppPackageInValidMakeShWrongName',
                     __DIR__
                 )
             )
@@ -100,7 +197,7 @@ final class MakeAppPackageTest extends TestCase
         );
     }
 
-    private function pathToInValidAppPackage(): string
+    private function pathToInvalidAppPackage_InvalidNumberOfCallsToDdmsNewApp(): string
     {
         $invalidPackageNames = ['ddmsTestAppPackageInValidMakeShMultiCallNewApp', 'ddmsTestAppPackageInValidMakeShSingleCallNewApp'];
         return strval(

--- a/tests/command/MakeAppPackageTest.php
+++ b/tests/command/MakeAppPackageTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace tests\command;
+
+use PHPUnit\Framework\TestCase;
+use ddms\classes\command\MakeAppPackage;
+use ddms\classes\ui\CommandLineUI;
+use ddms\interfaces\ui\UserInterface;
+use tests\traits\TestsCreateApps;
+use \RuntimeException;
+
+final class MakeAppPackageTest extends TestCase
+{
+
+    use TestsCreateApps;
+
+    public function testRunThrowsRuntimeExceptionIfPathIsNotSpecified(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        $preparedArguments = $makeAppPackage->prepareArguments([]);
+        $this->expectException(RuntimeException::class);
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunThrowsRuntimeExceptionIfSpecifiedPathIsNotValid(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        $preparedArguments = $makeAppPackage->prepareArguments(
+            [
+                '--path',
+                strval(rand(PHP_INT_MIN, PHP_INT_MAX))
+            ]
+        );
+        $this->expectException(RuntimeException::class);
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunThrowsRuntimeExceptionIfSpecifiedPathDoesNotInclude_make_sh_File(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        $preparedArguments = $makeAppPackage->prepareArguments(
+            [
+                '--path',
+                __DIR__
+            ]
+        );
+        $this->expectException(RuntimeException::class);
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunThrowsRuntimeExceptionIfSpecifiedPathIncludesA_make_sh_FileThatDoesNotDefineExactlyOneCallTo_ddms_new_app(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        $preparedArguments = $makeAppPackage->prepareArguments(
+            [
+                '--path',
+                $this->pathToInValidAppPackage()
+            ]
+        );
+        $this->expectException(RuntimeException::class);
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    public function testRunThrowsRuntimeExceptionIfSpecifiedPathIncludesA_make_sh_FileThatIsNotExecutable(): void
+    {
+        $makeAppPackage = new MakeAppPackage();
+        $preparedArguments = $makeAppPackage->prepareArguments(
+            [
+                '--path',
+                $this->pathToAppPackageWhoseMakeShIsNotExecutable()
+            ]
+        );
+        $this->expectException(RuntimeException::class);
+        $makeAppPackage->run(new CommandLineUI(), $preparedArguments);
+    }
+
+    private function pathToValidAppPackage(): string
+    {
+        return strval(
+            realpath(
+                str_replace(
+                    'tests' . DIRECTORY_SEPARATOR . 'command',
+                    'testAppPackages' . DIRECTORY_SEPARATOR . 'ddmsTestAppPackageValidMakeSh',
+                    __DIR__
+                )
+            )
+        );
+    }
+
+    private function pathToAppPackageWhoseMakeShIsNotExecutable(): string
+    {
+        return strval(
+            realpath(
+                str_replace(
+                    'tests' . DIRECTORY_SEPARATOR . 'command',
+                    'testAppPackages' . DIRECTORY_SEPARATOR . 'ddmsTestAppPackageInValidMakeShNotExecutable',
+                    __DIR__
+                )
+            )
+        );
+    }
+
+    private function pathToInValidAppPackage(): string
+    {
+        $invalidPackageNames = ['ddmsTestAppPackageInValidMakeShMultiCallNewApp', 'ddmsTestAppPackageInValidMakeShSingleCallNewApp'];
+        return strval(
+            realpath(
+                str_replace(
+                    'tests' . DIRECTORY_SEPARATOR . 'command',
+                    'testAppPackages' . DIRECTORY_SEPARATOR . $invalidPackageNames[array_rand($invalidPackageNames)],
+                    __DIR__
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
Finished initial development of ddms\classes\command\MakeAppPackage. 
Implemented the following tests:

```
     testRunThrowsRuntimeExceptionIfPathIsNotSpecified()
     testRunThrowsRuntimeExceptionIfSpecifiedPathIsNotValid()
     testRunThrowsRuntimeExceptionIfSpecifiedPathDoesNotInclude_make_sh_File()
     testRunThrowsRuntimeExceptionIfSpecifiedPathIncludesA_make_sh_FileThatDoesNotDefineExactlyOneCallTo_ddms_new_app()
     testRunThrowsRuntimeExceptionIfSpecifiedPathIncludesA_make_sh_FileThatIsNotExecutable()
     testRunThrowsRuntimeExceptionIfSpecifiedPathIncludesA_make_sh_WhoseCallToDdmsNewAppUsesANameThatDoesNotMatchTheAppPackagesName()
     testRunThrowsRuntimeExceptionIfAppWasAlreadyMade()

```

All PhpUnit and PhpStan tests are passing. Also manually tested `ddms --make-app-package` with various App Packages. This resolves issue #32.