### PR TITLE
Ddms0.0.8 beta | Refactored to remove App before making App Package, if App already exists

### DIFF
--- a/ddms/classes/command/MakeAppPackage.php
+++ b/ddms/classes/command/MakeAppPackage.php
@@ -40,8 +40,37 @@ class MakeAppPackage extends AbstractCommand implements Command
      * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
      */
     private function makeAppPackage(array $preparedArguments): void {
+        $this->removeAppIfItExists($preparedArguments);
         $this->showMessage(strval(shell_exec($this->determineMakeShPath($preparedArguments))));
         $this->copyAppPackageFilesAndDirectories($preparedArguments);
+    }
+
+    /**
+     * @param array{"flags": array<string, array<int, string>>, "options": array<int, string>} $preparedArguments
+     */
+    private function removeAppIfItExists(array $preparedArguments) : void {
+        $newAppPath = $this->newAppPath($preparedArguments);
+        if(file_exists($newAppPath) && is_dir($newAppPath)) {
+            self::removeDirectory($newAppPath);
+            var_dump('FOO', file_exists($newAppPath));
+        }
+    }
+
+    private static function removeDirectory(string $dir): void
+    {
+        if (is_dir($dir)) {
+            $contents = scandir($dir);
+            $contents = (is_array($contents) ? $contents : []);
+            foreach ($contents as $item) {
+                if ($item != "." && $item != "..") {
+                    $itemPath = $dir . DIRECTORY_SEPARATOR . $item;
+                    (is_dir($itemPath) === true && is_link($itemPath) === false)
+                        ? self::removeDirectory($itemPath)
+                        : unlink($itemPath);
+                }
+            }
+            rmdir($dir);
+        }
     }
 
     /**

--- a/helpFiles/make-app-package.txt
+++ b/helpFiles/make-app-package.txt
@@ -4,9 +4,13 @@
 
   Make an App Package into an App.
 
-  Note: With the exception of files ending in extension .sh and the DynamicOutput
-        directory, any files or directories defined by the App Package will be
-        copied to a corresponding path in the new App created by the App Package.
+  WARNING: If an App whose name matches the name of the App to be made already exists,
+           it will be replaced!
+
+  Note: With the exception of files ending in extension .sh, any files or directories
+        that exist in the App Package will be copied to a corresponding path in the
+        new App.
+
         For example, if the App Package defines a styles.css in AppPackage/css/styles.css
         it will be copied to NewApp/css/styles.css.
 


### PR DESCRIPTION

`ddms\classes\command\MakeAppPackage`: Refactored to remove App before making App Package, if App already exists. This change is an implementation detail, no new tests are needed, all existing PhpUnit and PhpStan tests are passing. This change was made as a convenience, it is reasonable to assume that whenever `ddms --make-app-package` is called the intent is to create or update the relevant App. 

`helpFiles`: Updated helpFiles/make-app-package.txt 