### PR TITLE
issue58: Resolved issue #58

### DIFF
--- a/ddms/classes/command/ConfigureAppOutput.php
+++ b/ddms/classes/command/ConfigureAppOutput.php
@@ -280,10 +280,10 @@ class ConfigureAppOutput extends AbstractCommand implements Command
                     $flags['name'][0],
                     '--for-app',
                     $flags['for-app'][0],
-                    '--requests', # @devNote: Requests MUST be defined last so Requests for urls can be added as final arguments!
-                    $flags['name'][0],
+                    (!isset($flags['global']) ? '--requests' : ''), # @devNote: Requests MUST be defined last so Requests for urls can be added as final arguments!
+                    (!isset($flags['global']) ? $flags['name'][0] : ''),
         ];
-        if(isset($flags['relative-urls']) && is_array($flags['relative-urls'])) {
+        if(!isset($flags['global']) && isset($flags['relative-urls']) && is_array($flags['relative-urls'])) {
             foreach($flags['relative-urls'] as $key => $relativeUrl) {
                 array_push($arguments, $flags['name'][0] . strval($key));
             }

--- a/tests/command/ConfigureAppOutputTest.php
+++ b/tests/command/ConfigureAppOutputTest.php
@@ -916,5 +916,37 @@ final class ConfigureAppOutputTest extends TestCase
             );
         }
     }
+
+    public function testRunDoesNotAssignAnyRequestsToGlobalResponses(): void
+    {
+         $preparedArguments = $this->configureAppOutput()->prepareArguments(
+            $this->getTestArgsForSpecifiedFlags(
+                [
+                    '--for-app',
+                    '--name',
+                    '--output',
+                    '--relative-urls',
+                    '--global'
+                ],
+                __METHOD__
+            )
+        );
+        $responseConfigurationFilePath = $this->determineConfigurationFilePath('Responses', $preparedArguments);
+        $this->configureAppOutput()->run($this->userInterface(), $preparedArguments);
+        $responseConfigurationFileContents = strval(
+            file_get_contents($responseConfigurationFilePath)
+        );
+        $configContents = str_replace([' ', '\n', '\r', PHP_EOL], '', $responseConfigurationFileContents);
+        $failureMessage = 'GlobalResponses must not be assigned any Requests, there is no reason to do so since they respond to all Requests, and doing so will just add clutter to GlobalResponse.';
+        $this->assertTrue(
+            str_contains($configContents, 'appComponentsFactory->buildGlobalResponse'),
+            $failureMessage
+        );
+        $this->assertTrue(
+            !str_contains($configContents, 'Request::class'),
+            $failureMessage
+        );
+    }
+
 }
 


### PR DESCRIPTION
issue58: Resolved issue #58, `ddms --configure-app-output` now only assigns Requests to Responses, not GlobalResponses, even if
`--relative-urls` are specified.