### PR TITLE
issue64: Resolved issue #64. 

### DIFF
--- a/ddms/classes/command/ConfigureAppOutput.php
+++ b/ddms/classes/command/ConfigureAppOutput.php
@@ -121,8 +121,8 @@ class ConfigureAppOutput extends AbstractCommand implements Command
                             $flags['for-app'][0],
                             '--name',
                             $flags['name'][0] . strval($key),
-                            '--relative-url',
-                            $relativeUrl,
+                            ($relativeUrl === '/' ? '' : '--relative-url'),
+                            ($relativeUrl === '/' ? '' : $relativeUrl),
                             '--container',
                             $flags['for-app'][0] . 'Requests'
                         ]

--- a/ddms/classes/command/NewRequest.php
+++ b/ddms/classes/command/NewRequest.php
@@ -29,7 +29,7 @@ class NewRequest extends AbstractCommand implements Command
     private function generateRequestConfigContent(array $flags): string
     {
         $template = strval(file_get_contents($this->pathToRequestTemplate()));
-        return str_replace(['_NAME_', '_CONTAINER_', '_RELATIVE_URL_'], [$flags['name'][0], ($flags['container'][0] ?? 'Requests'), ($flags['relative-url'][0] ?? 'index.php')], $template);
+        return str_replace(['_NAME_', '_CONTAINER_', '_RELATIVE_URL_'], [$flags['name'][0], ($flags['container'][0] ?? 'Requests'), ($flags['relative-url'][0] ?? '')], $template);
     }
 
     private function pathToRequestTemplate(): string

--- a/tests/command/NewRequestTest.php
+++ b/tests/command/NewRequestTest.php
@@ -117,7 +117,7 @@ final class NewRequestTest extends TestCase
         $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), file_get_contents($this->expectedRequestPath($preparedArguments)));
     }
 
-    public function testRunSetsRelativeUrlTo_index_php_IfRelativeUrlIsNotSpecified(): void
+    public function testRunSetsRelativeUrlToExpectedDefaultRelativeUrlIfRelativeUrlIsNotSpecified(): void
     {
         $appName = $this->createTestAppReturnName();
         $requestName = $appName . 'Request';
@@ -127,7 +127,7 @@ final class NewRequestTest extends TestCase
         $this->assertEquals($this->determineExpectedRequestPhpContent($preparedArguments), $this->getNewRequestContent($preparedArguments));
     }
 
-    public function testRunSetsRelativeUrlTo_index_php_IfRelativeUrlIsSpecifiedWithNoValue(): void
+    public function testRunSetsRelativeUrlToExpectedDefaultRelativeUrlIfRelativeUrlIsSpecifiedWithNoValue(): void
     {
         $appName = $this->createTestAppReturnName();
         $requestName = $appName . 'Request';
@@ -205,7 +205,7 @@ final class NewRequestTest extends TestCase
             [
                 $preparedArguments['flags']['name'][0],
                 ($preparedArguments['flags']['container'][0] ?? 'Requests'),
-                ($preparedArguments['flags']['relative-url'][0] ?? 'index.php')
+                ($preparedArguments['flags']['relative-url'][0] ?? '')
             ],
             strval(file_get_contents($this->expectedTemplateFilePath()))
         );


### PR DESCRIPTION
issue64: Resolved issue #64. 

Implemented the following new tests for `ddms\classes\command\NewRequest`.

```
testRunSetsRelativeUrlToExpectedDefaultRelativeUrlIfRelativeUrlIsNotSpecified()

testRunSetsRelativeUrlToExpectedDefaultRelativeUrlIfRelativeUrlIsSpecifiedWithNoValue()
```

`index.php `is no longer the default.

Now by default, `ddms --new-request` will use an empty string as a default
`--relative-url` in order to not interfere with the root domain configuration setup
by the file template..

I.e., it is assumed if no `--relative-urls` are passed to `ddms --new-request` that
the Request should be for the root domain.

Also refactored `ddms\classes\command\ConfigureAppOutput`. Implemented the following
new test:

`testRunConfiguresARequestForRootForRelativeUrlsWhoseValueIsABackslash()`

This is related to the changes to `ddms --new-request`, now `ddms
--configure-app-output` will configure a root request properly if the
string `/` is specified as one of the `--relative-urls`.

All PhpUnit and PhpStan --level 8 tests are passing.