### PR TITLE
Continued addressing issue #74.

### DIFF
--- a/helpFiles/new-global-response.txt
+++ b/helpFiles/new-global-response.txt
@@ -1,44 +1,51 @@
-ddms --new-global-response --for-app --name
-                           [--position] [--ddms-apps-directory-path]
+ddms --new-global-response --for-app --name [--position]
 
 Description:
 
-Create a new GlobalResponse for the specified App.
+Configure a new GlobalResponse for the specified App.
 
 Flags:
 
---for-app                    The name of the App to create the GlobalResponse
-                             for.
+--for-app    The name of the App to configure the GlobalResponse for.
 
---name                       A name to assign to the new GlobalResponse.
+             WARNING: The specified App must exist, if it does not, the new
+             GlobalResponse will not be configured.
 
-[--position]                 A position to assign to the new GlobalResponse.
-                             This value is used by the Darling Data Management
-                             System to sort Responses and GlobalResponse that
-                             respond to the same Request. Defaults to 0.
+--name       A name to assign to the new GlobalResponse.
 
-[--ddms-apps-directory-path] Path to the Darling Data Management Apps
-                             directory or, an alternative directory.
+             WARNING: The name must be unique, if a GlobalResponse already
+             exists with the same name the new GlobalResponse will not be
+             configured.
 
-                             If not specified, ddms will attempt to locate
-                             the Apps directory, if it cannot find it ddms
-                             will set --ddms-apps-directory-path to the
-                             path to ddms's tmp directory.
+             WARNING: The name must be alphanumeric with no spaces, if spaces
+             or non-alphanumeric characters are present in the specified name,
+             only the alphanumeric characters up to the first space or
+             non-alphanumeric character will be used.
 
-                             ddms will look for the Apps directory at
-                             the following path relative to ddms's root
-                             directory for an Apps directory:
+             For example:
 
-                               ../../../Apps
+                 ddms --new-global-response \
+                 --for-app foo \
+                 --name 'Spaces & Bad Chars'
 
-                             Defaults to:
+             Would result in the assigned name:
 
-                               ./tmp
+                 Spaces
+
+             It is also possible that ddms will refuse to configure the
+             GlobalResponse if an alphanumeric name cannot be derived from a name
+             that contains spaces or non-alphanumeric characters. This may happen,
+             for instance, if the specified name starts with a non-alphanumeric
+             character.
+
+[--position] The position to assign to the GlobalResponse. This position is used
+             to sort the GlobalResponse relative to other GlobalResponses and
+             Responses that respond to the same Request.
+             Defaults to: 0
 
 Examples:
 
-ddms --new-global-response --for-app Foo --name Foo
+ddms --new-global-response --for-app Foo --name Bar
 
-ddms --new-global-response --for-app Foo --name Bar --position 3
-
+ddms --new-global-response --for-app Foo --name Baz --position 3.5
 

--- a/helpFiles/new-response.txt
+++ b/helpFiles/new-response.txt
@@ -40,7 +40,8 @@ Flags:
 
 [--position] The position to assign to the Response. This position is used to
              sort the Response relative to other Responses and GlobalResponses
-             that respond to the same Request. Defaults to 0.
+             that respond to the same Request.
+             Defaults to: 0
 
 Examples:
 


### PR DESCRIPTION
Continued addressing issue #74. Revised `helpFiles/new-global-responses.txt`, and `helpFiles/new-response.txt`. All `phpunit` and `phpstan --level 8` tests are passing locally. Issue #74 is not resolved yet.