### PR TITLE
Continued addressing issue #74.

### DIFF
--- a/ddms/classes/ui/CommandLineUI.php
+++ b/ddms/classes/ui/CommandLineUI.php
@@ -25,7 +25,7 @@ class CommandLineUI implements UserInterface
   \e[0m\e[93m __| |__| |_ __  ___\e[0m
   \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
   \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-  \e[0m\e[105m\e[30m  v1.1.2 \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m" . PHP_EOL . PHP_EOL;
+  \e[0m\e[105m\e[30m  v1.1.3 \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m" . PHP_EOL . PHP_EOL;
     }
 
     /**

--- a/helpFiles/new-dynamic-output-component.txt
+++ b/helpFiles/new-dynamic-output-component.txt
@@ -1,58 +1,117 @@
-ddms --new-dynamic-output-component --for-app --name
-                                    [--container] [--position] [--file-name]
-                                    [--initial-output] [--initial-output-file]
-                                    [--shared] [--ddms-apps-directory-path]
+ddms --new-dynamic-output-component --for-app --name [--container]
+     [--file-name] [--initial-output-file] [--initial-output] [--position]
+     [--shared]
 
 Description:
 
-Create a new DynamicOutputComponent for the specified App.
+Configure a new DynamicOutputComponent for the specified App.
 
 Flags:
 
---for--app                   The name of the App to create the new DynamicOutputComponent
-                             for.
+--for--app                   The name of the App to configure the new
+                             DynamicOutputComponent for.
 
---name                       An alphanumeric name to assign to the new DynamicOutputComponent.
+                             WARNING: The specified App must exist, if it does
+                             not, the new DynamicOutputComponent will not be
+                             configured.
 
-[--container]                The container to store the new DynamicOutputComponent
-                             data in, defaults to DynamicOutput.
+--name                       An alphanumeric name to assign to the new
+                             DynamicOutputComponent.
 
-[--position]                 A numeric position to assign to the new DynamicOutputComponent,
-                             defaults to 0.
+                             WARNING: The name must be unique, if a
+                             DynamicOutputComponent already exists with the
+                             same name, the new DynamicOutputComponent will not
+                             be configured.
 
-[--file-name]                The name of the file that generates the DynamicOutputComponent's
-                             output. If not specified, the file-name will be assumed to match
-                             --name with the .php extension appended, for example:
+                             WARNING: The name must be alphanumeric with no
+                             spaces, if spaces or non-alphanumeric characters are
+                             present in the specified name, only the alphanumeric
+                             characters up to the first space or non-alphanumeric
+                             character will be used.
 
-                               ddmms --new-dynamic-output-component --for-app Foo --name Foo
+                             For example:
 
-                             Would assume the --file-name to be:
+                                 ddms --new-dynamic-output-component \
+                                 --for-app Foo \
+                                 --name 'Spaces & Bad Chars' \
+                                 --initial-output 'barBaz Foo'
 
-                               Foo.php
+                             Would result in the assigned name:
 
-                             ddms will create the file if it does not already exist.
+                                 Spaces
 
-                             The file is expected to exist either in the relevant
-                             App's DynamicOutput directory, or, if the --shared
-                             flag is specified, in the expected Darling Data
-                             Management System's SharedDynamicOutput directory.
+                             It is also possible that ddms will refuse to
+                             configure the DynamicOutputComponent if an
+                             alphanumeric name cannot be derived from a name that
+                             contains spaces or non-alphanumeric characters.
+                             This may happen, for instance, if the specified name
+                             starts with a non-alphanumeric character.
+
+[--container]                The container to store the new
+                             DynamicOutputComponent's data in. This value is used
+                             when an App is built for a domain, it determines
+                             where in the Domain's storage the
+                             DynamicOutputComponent's data will be located after
+                             the App is built.
+                             Defaults to: DynamicOutputComponents
+
+[--position]                 The position to assign to the DynamicOutputComponent.
+                             This position will be used to sort the
+                             DynamicOutputComponent relative to other
+                             DynamicOutputComponents and OutputComponents that
+                             are served by the same Response or GlobalResponse.
+                             Defaults to: 0
+
+[--file-name]                Either the name of an existing file that will
+                             generate the DynamicOutputComponent's output, or the
+                             name to assign to the file that will be created for
+                             the DynamicOutputComponent.
+
+                             The file, whether it is created or already exists,
+                             should be located either in the relevant App's
+                             DynamicOutput directory, or, if the --shared flag is
+                             specified, in the expected Darling Data Management
+                             System's SharedDynamicOutput directory.
+
+                             If the --file-name flag is not specified, the file
+                             name will be assumed to match the specified --name,
+                             with the extension ".php" appended.
+
+                             The path to the Darling Data Management System will
+                             correspond to the directory above the path assigned
+                             to the --ddms-apps-directory-path flag.
 
 [--initial-output]           The initial output to assign as the content of the
-                             new dynamic output file that will be created for
-                             the new DynamicOutputComponent. This flag will fail
-                             if the creation of the new dynamic output file would
-                             overwrite an existing dynamic output file. It will
-                             also fail if the --initial-output-file flag is also
-                             specified.
+                             new file that will be created for the new
+                             DynamicOutputComponent.
+
+                             WARNING:
+                             ddms will fail if the creation of the new file
+                             would overwrite an existing file.
+
+                             WARNING:
+                             The --initial-output and --initial-output-file flags
+                             cannot be used in conjunction with each other, if
+                             they are both specified ddms will not configure the
+                             new DynamicOutputComponent.
 
 [initial-output-file]        A path to a file whose content will be used as the
-                             new dynamic output file that will be created for
-                             the new DynamicOutputComponent. This flag will fail
-                             if the creation of the new dynamic output file would
-                             overwrite an existing dynamic output file. It will
-                             also fail if the --initial-output flag is also
-                             specified.
+                             contents of the new file that will be created to
+                             generate output for the new DynamicOutputComponent.
 
+                             WARNING:
+                             ddms will fail if the specifed file does not
+                             exist.
+
+                             WARNING:
+                             ddms will fail if the creation of the new file
+                             would overwrite an existing file.
+
+                             WARNING:
+                             The --initial-output-file and --initial-output flags
+                             cannot be used in conjunction with each other, if
+                             they are both specified ddms will not configure the
+                             new DynamicOutputComponent.
 
 [--shared]                   If specified, ddms will assume the file that generates
                              the output for the DynamicOutputComponent exists,
@@ -61,33 +120,25 @@ Flags:
 
                              ../SharedDynamicOutput
 
-                             If the dynamic output file has to be created, and the
-                             --shared flag is specified, and the SharedDynamicOutput
-                             directory does not exist at the expected path, it will
-                             be created.
-
-[--ddms-apps-directory-path] Path to the Darling Data Management Apps
-                             directory or, an alternative directory.
-
-                             If not specified, ddms will attempt to locate
-                             the Apps directory, if it cannot find it ddms
-                             will set --ddms-apps-directory-path to the
-                             path to ddms's tmp directory.
-
-                             ddms will look for the Apps directory at
-                             the following path relative to ddms's root
-                             directory:
-
-                               ../../../Apps
-
-                             Defaults to:
-
-                               ./tmp
+                             If the file has to be creted, and the --shared flag
+                             is specified, and the SharedDynamicOutput directory
+                             does not exist at the expected path, it will be
+                             created.
 
 Examples:
 
-ddms --new-dynamic-output-component --for-app Foo --name Foo --container FooOutput
+ddms --new-dynamic-output-component \
+--for-app Foo \
+--name Bar \
+--initial-output 'Foo bar bazzer'
 
-ddms --new-dynamic-output-component --for-app Foo --name Foo --position 3
+ddms --new-dynamic-output-component \
+--for-app Foo \
+--name Bin \
+--container 'SpecifiedContainer' \
+--file-name 'SpecifiedFileName.txt' \
+--initial-output-file /path/to/intial/output/file.txt \
+--position '2.7' \
+--shared
 
-ddms --new-dynamic-output-component --for-app Foo --name Foo --file-name Baz.html --shared
+

--- a/helpFiles/new-output-component.txt
+++ b/helpFiles/new-output-component.txt
@@ -14,7 +14,7 @@ Flags:
 --name        An alphanumeric name to assign to the new OutputComponent.
 
               WARNING: The name must be unique, if an OutputComponent already
-              exists with the same name the new OutputComponent will not be
+              exists with the same name, the new OutputComponent will not be
               configured.
 
               WARNING: The name must be alphanumeric with no spaces, if spaces
@@ -45,12 +45,13 @@ Flags:
               value is used when an App is built for a domain, it determines
               where in the Domain's storage the OutputComponent's data will be
               located after the App is built.
-              Defaults to: Output
+              Defaults to: OutputComponents
 
 [--position]  The position to assign to the OutputComponent. This position will
               be used to sort the OutputComponent relative to other
-              OutputComponents that are served by the same Response or
-              GlobalResponse.
+              OutputComponents and DynamicOutputComponents that are served by the
+              same Response or GlobalResponse.
+              Defaults to: 0
 
 Examples:
 

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -76,7 +76,7 @@ final class CommandLineUITest extends TestCase
   \e[0m\e[93m __| |__| |_ __  ___\e[0m
   \e[0m\e[94m/ _` / _` | '  \(_-<\e[0m
   \e[0m\e[91m\__,_\__,_|_|_|_/__/\e[0m
-  \e[0m\e[105m\e[30m  v1.1.2 \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m" . PHP_EOL . PHP_EOL;
+  \e[0m\e[105m\e[30m  v1.1.3 \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m" . PHP_EOL . PHP_EOL;
     }
 
 }


### PR DESCRIPTION
Continued addressing issue #74. Revised `helpFiles/new-dynamic-output-component.txt`. All `phpunit` and `phpstan --level 8` tests are passing locally. Issue #74 is not resolved yet.