### PR TITLE
Addressed issue #95.

### DIFF
--- a/FileTemplates/Components.php
+++ b/FileTemplates/Components.php
@@ -42,7 +42,7 @@
  *            http://localhost:8080
  */
 
-use DarlingDataManagementSystem\classes\utility\AppBuilder;
+use roady\classes\utility\AppBuilder;
 
 ini_set('display_errors', 'true');
 

--- a/FileTemplates/GlobalResponse.php
+++ b/FileTemplates/GlobalResponse.php
@@ -2,8 +2,8 @@
 
 /** _NAME_.php */
 
-use DarlingDataManagementSystem\classes\component\OutputComponent;
-use DarlingDataManagementSystem\classes\component\DynamicOutputComponent;
+use roady\classes\component\OutputComponent;
+use roady\classes\component\DynamicOutputComponent;
 
 $appComponentsFactory->buildGlobalResponse(
     '_NAME_',

--- a/FileTemplates/Response.php
+++ b/FileTemplates/Response.php
@@ -2,9 +2,9 @@
 
 /** _NAME_.php */
 
-use DarlingDataManagementSystem\classes\component\OutputComponent;
-use DarlingDataManagementSystem\classes\component\DynamicOutputComponent;
-use DarlingDataManagementSystem\classes\component\Web\Routing\Request;
+use roady\classes\component\OutputComponent;
+use roady\classes\component\DynamicOutputComponent;
+use roady\classes\component\Web\Routing\Request;
 
 $appComponentsFactory->buildResponse(
     '_NAME_',

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rig
 
-Command line utility designed to aide in development with the Darling Data Management System
+Command line utility designed to aide in development with Roady
 
 To install run:
 

--- a/bin/rig.php
+++ b/bin/rig.php
@@ -1,9 +1,9 @@
 <?php
 
-$darlingDataManagementSystemAutoloader = strval(realpath(str_replace('darling' . DIRECTORY_SEPARATOR . 'rig' . DIRECTORY_SEPARATOR . 'bin', '', __DIR__) . DIRECTORY_SEPARATOR . 'autoload.php'));
+$roadyAutoloader = strval(realpath(str_replace('darling' . DIRECTORY_SEPARATOR . 'rig' . DIRECTORY_SEPARATOR . 'bin', '', __DIR__) . DIRECTORY_SEPARATOR . 'autoload.php'));
 $standaloneAutoloader = strval(realpath(str_replace('bin', '', __DIR__) . DIRECTORY_SEPARATOR . 'vendor/autoload.php'));
-if(file_exists($darlingDataManagementSystemAutoloader)) {
-    require $darlingDataManagementSystemAutoloader;
+if(file_exists($roadyAutoloader)) {
+    require $roadyAutoloader;
 } else {
     require $standaloneAutoloader;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "darling/rig",
-    "description": "Command line utility designed to aide in development with the Darling Data Management System",
+    "description": "Command line utility designed to aide in development with Roady",
     "type": "command-line-utility",
     "license": "MIT",
     "authors": [

--- a/helpFiles/assign-to-response.txt
+++ b/helpFiles/assign-to-response.txt
@@ -4,8 +4,8 @@ rig --assign-to-response --for-app --response [--dynamic-output-components]
 Description:
 
 Assign one or more Requests, OutputComponents, or DynamicOutputComponents to an
-existing Response or GlobalResponse for an existing Darling Data Management
-System App.
+existing Response or GlobalResponse for an existing Roady
+App.
 
 Flags:
 

--- a/helpFiles/help.txt
+++ b/helpFiles/help.txt
@@ -8,7 +8,7 @@ rig [--assign-to-response] [--configure-app-output] [--path-to-apps-directory]
 Description:
 
 rig is a command line utility designed to aide in the development process
-with the Darling Data Management System. rig provides a number of flags
+with Roady. rig provides a number of flags
 that can be used to perform common development tasks.
 
 
@@ -17,7 +17,7 @@ Flags:
 [--assign-to-response]              Assign one or more Requests, OutputComponents,
                                     or DynamicOutputComponents to an existing
                                     Response or GlobalResponse for an existing
-                                    Darling Data Management System App.
+                                    Roady App.
 
 [--configure-app-output]            Configure output for a specified App to
                                     show up in response to specified Requests.
@@ -25,7 +25,7 @@ Flags:
                                     Note: If the specified App does not exist
                                     it will be created.
 
-[--path-to-apps-directory]          The path to the Darling Data Management Apps
+[--path-to-apps-directory]          The path to Roady Apps
                                     directory, or an alternative directory.
 
                                     If not specified, rig will attempt to locate
@@ -100,28 +100,28 @@ Flags:
 
                                         rig --help --new-app
 
-[--make-app-package]                Make an App Package into a Darling Data
-                                    Management System App.
+[--make-app-package]                Make an App Package into a Roady
+                                    App.
 
 [--new-app-package]                 Create a new app package.
 
-[--new-app]                         Create a new Darling Data Management System
+[--new-app]                         Create a new Roady
                                     App.
 
 [--new-dynamic-output-component]    Configure a new DynamicOutputComponent for a
-                                    Darling Data Management System App.
+                                    Roady App.
 
-[--new-global-response]             Configure a new GlobalResponse for a Darling
-                                    Data Management System App.
+[--new-global-response]             Configure a new GlobalResponse for a Roady
+                                    App.
 
-[--new-output-component]            Configure a new OutputComponent for a Darling
-                                    Data Management System App.
+[--new-output-component]            Configure a new OutputComponent for a Roady
+                                    App.
 
-[--new-request]                     Configure a new Request for a Darling Data
-                                    Management System App.
+[--new-request]                     Configure a new Request for a Roady
+                                    App.
 
-[--new-response]                    Configure a new Response for a Darling Data
-                                    Management System App.
+[--new-response]                    Configure a new Response for a Roady
+                                    App.
 
 [--start-server]                    Start a development server.
 
@@ -193,7 +193,7 @@ rig --help --start-server
 rig --help view-active-servers
 rig --help --view-active-servers
 
-Documentation for rig and the Darling Data Management System can be found at:
+Documentation for rig and Roady can be found at:
 
   https://darlingdata.tech
 
@@ -201,16 +201,16 @@ rig is available on GitHub:
 
   https://github.com/sevidmusic/rig
 
-The Darling Data Management System is available on GitHub:
+Roady is available on GitHub:
 
-  https://github.com/sevidmusic/DarlingDataManagementSystem
+  https://github.com/sevidmusic/roady
 
-A repo of supported App Packages that can be made into Darling Data Management
-System Apps via rig --make-app-package is available on GitHub:
+A repo of supported App Packages that can be made into Roady
+Apps via rig --make-app-package is available on GitHub:
 
   https://github.com/sevidmusic/rigAppPackages
 
-The Darling Data Managment System, the rig command line utility, and
+Roady, the rig command line utility, and
 rigAppPackages are all licensed under the MIT license.
 
 MIT License

--- a/helpFiles/make-app-package.txt
+++ b/helpFiles/make-app-package.txt
@@ -7,12 +7,12 @@ that corresponds to the value assigned to the --path-to-apps-directory flag.
 
 For example, if --path-to-apps-directory is assigned the path:
 
-    /path/to/DarlingDataManagementSystem/Apps
+    /path/to/roady/Apps
 
 Then rig --make-app-package --path /path/to/AppPackage/Foo would make the Foo
 App at:
 
-    /path/to/DarlingDataManagementSystem/Apps/Foo
+    /path/to/roady/Apps/Foo
 
 Note:    You do not need to explicitly set the --path-to-apps-directory unless
          you intend to use an alternative Apps directory.

--- a/helpFiles/new-app.txt
+++ b/helpFiles/new-app.txt
@@ -2,13 +2,13 @@ rig --new-app --name [--domain]
 
 Description:
 
-Creates a new Darling Data Management System App. The new App will be created at
+Creates a new Roady App. The new App will be created at
 the path that corresponds to the value assigned to the --path-to-apps-directory
 flag.
 
 For example, if the --path-to-apps-directory flag is assigned the path:
 
-    /path/to/DarlingDataManagementSystem/Apps
+    /path/to/roady/Apps
 
 Then:
 
@@ -16,7 +16,7 @@ Then:
 
 Would create the new Foo App at:
 
-    /path/to/DarlingDataManagementSystem/Apps/Foo
+    /path/to/roady/Apps/Foo
 
 Note: You do not need to explicitly set the --path-to-apps-directory unless you
 intend to use an alternative Apps directory. The --path-to-apps-directory flag's
@@ -61,7 +61,7 @@ Flags:
                              of the domain or you may run into issues. This is
                              a bug, and it is being addressed. See issue #193:
 
-                             https://github.com/sevidmusic/DarlingDataManagementSystem/issues/193
+                             https://github.com/sevidmusic/roady/issues/193
 
 Examples:
 

--- a/helpFiles/new-dynamic-output-component.txt
+++ b/helpFiles/new-dynamic-output-component.txt
@@ -72,11 +72,11 @@ Flags:
 
                              Note: If the --shared flag is specified, then the
                              file will be created or expected to exist in
-                             the Darling Data Management System's
+                             Roady's
                              SharedDynamicOutput directory instead of in the
                              App's DynamicOutput directory.
 
-                             Note: The path to the Darling Data Management System
+                             Note: The path to Roady
                              SharedDynamicOutput directory will correspond to the
                              following path relative to the path assigned to the
                              --path-to-apps-directory flag:

--- a/helpFiles/path-to-apps-directory.txt
+++ b/helpFiles/path-to-apps-directory.txt
@@ -1,7 +1,7 @@
 [--path-to-apps-directory]
 
 This flag can be used in conjunction with other rig flags to manually set the
-Darling Data Management Apps directory path used by rig to an alternative
+Roady Apps directory path used by rig to an alternative
 Apps directory path.
 
 Typically it is not necessary to specify this flag. rig will attempt to locate

--- a/helpFiles/start-server.txt
+++ b/helpFiles/start-server.txt
@@ -10,14 +10,14 @@ WARNING: Do not use php's built in server in production, it is meant for
 
          https://www.php.net/manual/en/features.commandline.webserver.php
 
-Once a sever is started, it can be used to run one or more Darling Data
-Management System Apps locally by building the Apps to run for a domain that
+Once a sever is started, it can be used to run one or more Roady
+Apps locally by building the Apps to run for a domain that
 corresponds to a running development server instance's url.
 
 For example, to run an existing App named Foo locally on http://localhost:8080:
 
     # Build the App for the domain 'http://localhost:8080'
-    php /path/to/DarlingDataManagementSystem/Apps/Foo/Components.php 'http://localhost:8080'
+    php /path/to/roady/Apps/Foo/Components.php 'http://localhost:8080'
 
     # Start a local development server on port 8080
     rig --start-server --port 8080
@@ -41,11 +41,11 @@ Flags:
                       Defaults to the directory above --path-to-apps-directory.
                       For example, if --path-to-apps-directory is:
 
-                          $HOME/DarlingDataManagementSystem/Apps
+                          $HOME/roady/Apps
 
                       Then default --root-dir will be:
 
-                          $HOME/DarlingDataManagementSystem
+                          $HOME/roady
 
                       If the --path-to-apps-directory is:
 

--- a/rig/abstractions/command/AbstractCommand.php
+++ b/rig/abstractions/command/AbstractCommand.php
@@ -35,7 +35,7 @@ abstract class AbstractCommand implements Command
      */
     private function determineDefaultAppsDirectoryPath(array $flags): string
     {
-        $expectedDarlingDMSAppsDirectory = strval(
+        $expectedRoadyAppsDirectory = strval(
             realpath(
                 str_replace(
                     'vendor' . DIRECTORY_SEPARATOR . 'darling' . DIRECTORY_SEPARATOR . 'rig' . DIRECTORY_SEPARATOR . 'rig' . DIRECTORY_SEPARATOR . 'abstractions' . DIRECTORY_SEPARATOR .  'command',
@@ -44,8 +44,8 @@ abstract class AbstractCommand implements Command
             )
         );
         $rigTmpDirectoryPath = strval(realpath(str_replace('rig' . DIRECTORY_SEPARATOR . 'abstractions' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__)));
-        if(!in_array('path-to-apps-directory', array_keys($flags)) && substr($expectedDarlingDMSAppsDirectory, -4, 4) === 'Apps' && file_exists($expectedDarlingDMSAppsDirectory) && is_dir($expectedDarlingDMSAppsDirectory)) {
-            return $expectedDarlingDMSAppsDirectory;
+        if(!in_array('path-to-apps-directory', array_keys($flags)) && substr($expectedRoadyAppsDirectory, -4, 4) === 'Apps' && file_exists($expectedRoadyAppsDirectory) && is_dir($expectedRoadyAppsDirectory)) {
+            return $expectedRoadyAppsDirectory;
         }
         return $rigTmpDirectoryPath;
     }

--- a/tests/command/AbstractCommandTest.php
+++ b/tests/command/AbstractCommandTest.php
@@ -48,22 +48,22 @@ final class AbstractCommandTest extends TestCase
         );
     }
 
-    private function determineExpectedDarlingDMSAppsDirectory(): string
+    private function determineExpectedRoadyAppsDirectory(): string
     {
-        // This path is used if rig is istalled  inside the DarlingDataManagementSystem's vendor directory, or mock vendor directory.
-        $expectedDarlingDMSAppsDirectory = strval(realpath(str_replace('vendor' . DIRECTORY_SEPARATOR . 'darling' . DIRECTORY_SEPARATOR . 'rig' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR .  'command', 'Apps', __DIR__)));
-        if(substr($expectedDarlingDMSAppsDirectory, -4, 4) === 'Apps' && file_exists($expectedDarlingDMSAppsDirectory) && is_dir($expectedDarlingDMSAppsDirectory)) {
-            return $expectedDarlingDMSAppsDirectory;
+        // This path is used if rig is istalled  inside roady's vendor directory, or mock vendor directory.
+        $expectedRoadyAppsDirectory = strval(realpath(str_replace('vendor' . DIRECTORY_SEPARATOR . 'darling' . DIRECTORY_SEPARATOR . 'rig' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR .  'command', 'Apps', __DIR__)));
+        if(substr($expectedRoadyAppsDirectory, -4, 4) === 'Apps' && file_exists($expectedRoadyAppsDirectory) && is_dir($expectedRoadyAppsDirectory)) {
+            return $expectedRoadyAppsDirectory;
         }
-        // This path is used if rig is not installed inside the DarlingDataManagementSystem's vendor directory, or mock vendor directory.
+        // This path is used if rig is not installed inside roady's vendor directory, or mock vendor directory.
         return strval(realpath(str_replace('tests' . DIRECTORY_SEPARATOR . 'command', 'tmp', __DIR__)));
     }
 
-    public function testPrepareArgumentsReturnsArrayWhose_rig_apps_directory_path_FlagsFirstArgumentIsAssignedPathToExpectedDarlingDataManagementSystemAppsDirectoryOr_rig_tmp_DirectoryIf_rig_apps_directory_path_FlagIsNotSpecified(): void
+    public function testPrepareArgumentsReturnsArrayWhose_rig_apps_directory_path_FlagsFirstArgumentIsAssignedPathToExpectedroadyAppsDirectoryOr_rig_tmp_DirectoryIf_rig_apps_directory_path_FlagIsNotSpecified(): void
     {
-        $expectedDarlingDMSAppsDirectory = $this->determineExpectedDarlingDMSAppsDirectory();
+        $expectedRoadyAppsDirectory = $this->determineExpectedRoadyAppsDirectory();
         $this->assertEquals(
-            $expectedDarlingDMSAppsDirectory,
+            $expectedRoadyAppsDirectory,
             $this->getMockCommand()->prepareArguments([])['flags']['path-to-apps-directory'][0]
         );
     }

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -1,7 +1,7 @@
 The tmp/ directory is used by rig in circumstances when an appropriate directory
 path cannot be determined.
 
-For example, if `rig --new-app` is run and the path to the DarlingDataManagmentSystem's
+For example, if `rig --new-app` is run and the path to roady's
 Apps directory cannot be determined, the new App will be created in the tmp/ directory.
 
 If you find this directory is populated by rig, it means that one of the following


### PR DESCRIPTION
Addressed issue #95. Refactored references to `Darling Data Management System` to reference the new name: `Roady`. All local `phpunit` and` phpstan --level 8` tests are passing.