### PR TITLE
Addressed issue #165.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1865,6 +1865,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {

--- a/rig/classes/command/StartServer.php
+++ b/rig/classes/command/StartServer.php
@@ -39,7 +39,7 @@ class StartServer extends AbstractCommand implements Command
             (isset($flags['php-ini'][0]) ? ' -c ' . escapeshellarg($flags['php-ini'][0]) : '') .
             ' >> ' . $serverLogPath .
             ' 2>> ' . $serverLogPath .
-            (isset($flags['open-in-browser']) ? ' & xdg-open ' . $domain . ' &> /dev/null' : '') .
+            (isset($flags['open-in-browser']) ? ' & nohup xdg-open ' . $domain . ' >/dev/null 2>&1' : '') .
             ' &'
         );
     }


### PR DESCRIPTION
Addressed issue #165.

The fix implemented for issue #157 was wrong. 

Issue #157 was the result of `disown` not always being available.

 `disown` is used by `rig --start-server` to remove the "job" it starts from the job list so, for instance, the terminal can be closed without killing the server or closing the browser that were started with `rig --start-server` or `rig --start-server --open-in-browser`.

The fix for #157 was to not call `disown` and rely on `&` to just put job in the background. 

This is not working as expected.

If `rig --start-server` is called there is no issue, the job is put in the background, and closing the terminal does not kill the server that was started.

But if `rig --start-server --open-in-browser` is called, the job for xdg-open (which is used by `rig --start-server` to open the browser) is not put in the background even though it is followed by `&`, and if the terminal is closed both the server and the browser are killed.

The use of `disown` was ideal, but it is not available for instance in `sh`.

Digging into `disown` the following stackoverflow post was quite helpful, and recommends the use of `nohup`:

https://unix.stackexchange.com/questions/147760/detach-a-process-from-sh-not-bash-or-disown-for-sh-not-bash

Also, the following post was quite helpful:

https://unix.stackexchange.com/questions/3886/difference-between-nohup-disown-and

Try using `nohup` instead of `disown` or `&` as a possible fix to issue #157.

Refactored the following lines in `rig/classes/command/StartServer.php`:
```
shell_exec(
            '/usr/bin/php -S ' . $localhost . ' -t ' . $rootDirectory .
            (isset($flags['php-ini'][0]) ? ' -c ' . escapeshellarg($flags['php-ini'][0]) : '') .
            ' >> ' . $serverLogPath .
            ' 2>> ' . $serverLogPath .
            (isset($flags['open-in-browser']) ? ' & xdg-open ' . $domain . ' &> /dev/null' : '') .
            ' &'
        );
```

To be:
```
shell_exec(
            '/usr/bin/php -S ' . $localhost . ' -t ' . $rootDirectory .
            (isset($flags['php-ini'][0]) ? ' -c ' . escapeshellarg($flags['php-ini'][0]) : '') .
            ' >> ' . $serverLogPath .
            ' 2>> ' . $serverLogPath .
            (isset($flags['open-in-browser']) ? ' & nohup xdg-open ' . $domain . ' >/dev/null 2>&1' : '') .
            ' &'
        );
```
