### PR TITLE
Updated version number shown by CommandLineUI from 1.6.3 to 1.6.4

### DIFF
--- a/rig/classes/ui/CommandLineUI.php
+++ b/rig/classes/ui/CommandLineUI.php
@@ -26,7 +26,7 @@ class CommandLineUI implements UserInterface
   \e[0m\e[93m   |    | (   |  \e[0m
   \e[0m\e[96m  _|   _|\__, |  \e[0m
   \e[0m\e[92m         |___/  \e[0m
-  \e[0m\e[105m\e[30m  v1.6.3 \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m" . PHP_EOL . PHP_EOL;
+  \e[0m\e[105m\e[30m  v1.6.4 \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m" . PHP_EOL . PHP_EOL;
     }
 
     /**

--- a/tests/command/ViewActiveServersTest.php
+++ b/tests/command/ViewActiveServersTest.php
@@ -27,7 +27,7 @@ final class ViewActiveServersTest extends TestCase
             ' >> ' . $serverLogPath . # redirect sdout to server log
             ' 2>> ' . $serverLogPath . # redirect sderr to server log
             ' & sleep .09' . # give server a momement
-            ' & disown' # send all to bg and disown
+            ' & ' # send to bg
         );
     }
 

--- a/tests/ui/CommandLineUITest.php
+++ b/tests/ui/CommandLineUITest.php
@@ -77,7 +77,7 @@ final class CommandLineUITest extends TestCase
   \e[0m\e[93m   |    | (   |  \e[0m
   \e[0m\e[96m  _|   _|\__, |  \e[0m
   \e[0m\e[92m         |___/  \e[0m
-  \e[0m\e[105m\e[30m  v1.6.3 \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m" . PHP_EOL . PHP_EOL;
+  \e[0m\e[105m\e[30m  v1.6.4 \e[0m\e[0m\e[101m\e[30m  " . date('h:i:s A') . "  \e[0m" . PHP_EOL . PHP_EOL;
     }
 
 }


### PR DESCRIPTION
Updated version number shown by `CommandLineUI` from `1.6.3` to `1.6.4`

Removed call to `disown` in `tests/command/ViewActiveServersTest.php`.
`disown` causes problems because it is not available to all shells,
`sh` for example does not support `disown`.