### PR TITLE
Fixed bad reference to `setup.sh` in `composer.json`, now correctly references `setupRig.sh`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,5 @@
         "darling/php-unit-test-utilities": "^1.0",
         "laravel/prompts": "^0.1.16"
     },
-    "bin": ["rig", "rig.php", "setup.sh"]
+    "bin": ["rig", "rig.php", "setupRig.sh"]
 }


### PR DESCRIPTION
Fixed bad reference to `setup.sh` in `composer.json`, now correctly references `setupRig.sh`